### PR TITLE
test(shared): use assertFailsWith in SmokingAreaRepositoryTest

### DIFF
--- a/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/smokingArea/SmokingAreaRepositoryTest.kt
+++ b/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/smokingArea/SmokingAreaRepositoryTest.kt
@@ -7,7 +7,7 @@ import app.kaito_dogi.smopin.shared.domain.smokingArea.SmokingArea
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 internal class SmokingAreaRepositoryTest {
   @Test
@@ -39,11 +39,8 @@ internal class SmokingAreaRepositoryTest {
       ),
     )
 
-    // TODO: Exception をテストできるようにする
-    try {
+    assertFailsWith<IllegalStateException> {
       smokingAreaRepository.getSmokingAreaList()
-    } catch (e: Exception) {
-      assertTrue { true }
     }
   }
 }
@@ -55,7 +52,7 @@ private class FakeSmokingAreaNetworkDataSource(
   override suspend fun getSmokingAreaList(): List<SmokingAreaDataModel> = if (!shouldThrow) {
     smokingAreaList
   } else {
-    throw Exception()
+    throw IllegalStateException()
   }
 }
 


### PR DESCRIPTION
### Motivation
- Replace a fragile `try/catch` TODO in the error case with a clear, type-safe assertion so the test explicitly verifies the failure mode.

### Description
- Updated `SmokingAreaRepositoryTest` to import and use `assertFailsWith` and replaced the manual `try/catch` in `getSmokingAreaList_Error` with `assertFailsWith<IllegalStateException>`.
- Modified the test `FakeSmokingAreaNetworkDataSource` to throw `IllegalStateException` for the error scenario so the test can assert the concrete exception type.

### Testing
- Ran `./gradlew :shared:data:test --stacktrace`; the run failed to start tests due to an environment Java runtime parsing error (`IllegalArgumentException: 25.0.1`) before test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886bf6f9788320926b0a1ba35c3844)