### PR TITLE
Add doc summaries and contributor onboarding guide

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# CONTRIBUTING
+
+本ドキュメントは、`smopin` にコントリビュートする開発者向けのガイドです。
+
+## 1. 開発の前提
+
+- 本プロジェクトは Kotlin Multiplatform（KMP）を前提に、`android` / `ios` / `shared` を分離して開発します。
+- 設計方針の一次情報は `doc/` 配下の戦略・規約ドキュメントです。
+- 実装前に以下を確認してください。
+  - `doc/strategy-modularization.md`
+  - `doc/strategy-dependency-injection.md`
+  - `doc/convention-layer-data.md`
+  - `doc/CONVENTION_CODING.md`
+
+## 2. 推奨ワークフロー
+
+1. Issue で目的・完了条件を確認する。
+2. 影響範囲のモジュール（`shared/*`, `android/*`, `ios/*`）を特定する。
+3. 設計ドキュメントの方針と矛盾しない実装案を作る。
+4. 実装し、ローカルでビルド/テストを実行する。
+5. 変更内容とテスト結果を明記して Pull Request を作成する。
+
+## 3. 実装ルール（要点）
+
+### 命名・コードスタイル
+
+- 命名に曖昧な複数形を使わず、型名（`List` など）を明示する。
+- Kotlin の expression body を積極的に使う。
+- モデルには KDoc を記述する。
+- `value class` は Swift 互換性のため使用しない。
+
+### レイヤ構成
+
+- Repository は Data Layer の SSOT とする。
+- Domain のインターフェースを Data 側で実装し、UI には Domain 抽象を公開する。
+- DataSource は単一データソース責務（network / database / preferences など）に限定する。
+
+### DI
+
+- Metro を利用する。
+- インターフェースの束縛は `@Binds`、外部インスタンスの提供は `@Provides` を使う。
+- 具象実装は原則 `internal` とし、モジュール外に漏らさない。
+
+## 4. モジュール追加・変更時の注意
+
+- モジュールは「必要性が明確になってから」追加する。
+- 依存関係は `doc/strategy-modularization.md` の方針（依存性逆転含む）に合わせる。
+- 新しい共通ルールを導入した場合は、実装と同時に `doc/` の関連ドキュメントを更新する。
+
+## 5. テスト方針
+
+- まずは変更箇所に近い単体テストを優先する。
+- Data Layer は Fake 実装を使ったテストを基本とする。
+- 仕様変更を伴う場合、テスト追加とドキュメント更新をセットで行う。
+
+## 6. Pull Request のチェックリスト
+
+- [ ] 変更目的と背景を PR に記載した
+- [ ] 影響範囲（モジュール/レイヤ）を説明した
+- [ ] ビルドまたはテスト結果を記載した
+- [ ] 必要なドキュメント更新を行った
+- [ ] 既存規約（coding / layer / DI / modularization）との整合性を確認した

--- a/doc/test-codex.md
+++ b/doc/test-codex.md
@@ -1,0 +1,41 @@
+# Codex テスト: `doc/` 配下ドキュメント要約
+
+Issue #1 の完了条件に基づき、`doc/` 配下の既存 Markdown を確認して要約を整理した。
+
+## `doc/CONVENTION_CODING.md`
+
+- Kotlin 実装のコーディング規約を定義。
+- 命名では不規則な複数形を避け、`List` / `Map` / `Set` など型を明示する方針。
+- 式で書ける関数は expression body（`=`）を使って簡潔に記述する。
+- モデルには KDoc を書き、`value class` は Swift 互換性の理由で使用しない。
+- DataSource はコンストラクタインジェクションで `Dispatchers.IO` を受け取り、メソッド内で `withContext` を呼ぶ。
+
+## `doc/CONVENTION_DOC.md`
+
+- ドキュメントの命名規則と記法ルールを定義。
+- ファイル名は `{種類名}_{具体名}.md` 形式を推奨。
+- 絵文字の意味を定義（🚨: 要議論、✍️: 要追記）。
+
+## `doc/convention-layer-data.md`
+
+- Data Layer の原則、責務分離、実装方針を整理。
+- Repository を Data Layer の SSOT とし、Domain のインターフェース実装として UI へデータ公開する。
+- DataSource は単一データソースを担当し、Data モデルと Domain モデルを分離する。
+- 処理を UI 指向 / アプリケーション指向 / ビジネス指向に分類し、ライフサイクルに応じた実行方針を示す。
+- エラーハンドリング、Worker の配置、iOS 実装、結合テストには TBD/議論項目が残る。
+
+## `doc/strategy-dependency-injection.md`
+
+- KMP 前提の DI 戦略を説明。
+- Metro を採用し、`DependencyGraph` と `BindingContainer` で依存グラフを構成する方針。
+- UseCase / Repository / DataSource をインターフェース化し、具象実装は `internal` で隠蔽する。
+- インターフェース束縛は `@Binds`、外部インスタンス注入は `@Provides` を使い分ける。
+- スコープ運用やテスト差し替えの基本方針と、今後の TBD 項目を明示。
+
+## `doc/strategy-modularization.md`
+
+- モジュール・パッケージ分割戦略を整理。
+- 優先順位は「再利用性 > シンプルさ > その他のマルチモジュール利点」。
+- 依存性逆転を採用し、Data Layer が Domain Layer に依存する構成を採る。
+- `shared` / `android` / `ios` のモジュール責務と依存関係を定義し、Mermaid で可視化。
+- `shared:domain` は知識単位、`android:ui` は責務単位でパッケージ分割する方針。


### PR DESCRIPTION
### Motivation

- Satisfy Issue #1 by summarizing existing `doc/` Markdown files and providing onboarding documentation for contributors.

### Description

- Add `doc/test-codex.md` that consolidates concise summaries of `doc/CONVENTION_CODING.md`, `doc/CONVENTION_DOC.md`, `doc/convention-layer-data.md`, `doc/strategy-dependency-injection.md`, and `doc/strategy-modularization.md`.
- Add `doc/CONTRIBUTING.md` containing a contributor-facing guide covering project assumptions, recommended workflow, implementation rules (naming, layers, DI), testing guidance, and a PR checklist.
- Changes are limited to documentation under the `doc/` directory and do not modify source code.

### Testing

- Ran `git diff --check` to validate whitespace and diff issues, which completed without errors.
- Ran `git status --short` and inspected the new files to confirm they appear in the working tree as expected and contain the intended content.
- Created a pull request via the repository tooling to publish these changes for review, and the PR creation step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889ea148b48320959cdeec82e2d127)