### PR TITLE
Add Android UI-testing module with Paparazzi VRT and Compose preview snapshots

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -1,0 +1,50 @@
+name: VRT
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Verify screenshots
+        run: ./gradlew :android:ui-testing:verifyPaparazziDebug
+      - name: Upload VRT reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: paparazzi-diff
+          path: |
+            **/build/reports/paparazzi/**
+            **/build/paparazzi/failures/**
+
+  record:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Record screenshots
+        run: ./gradlew :android:ui-testing:recordPaparazziDebug
+      - name: Upload recorded screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: paparazzi-recordings
+          path: '**/src/test/snapshots/**'

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.zacsweers.metrox.viewmodel.metroViewModel
@@ -24,6 +25,17 @@ fun HogeScreen(
     }
   }
 
+  HogeScreenContent(
+    modifier = modifier,
+    uiState = uiState,
+  )
+}
+
+@Composable
+internal fun HogeScreenContent(
+  uiState: HogeUiState,
+  modifier: Modifier = Modifier,
+) {
   Column(
     modifier = modifier,
   ) {
@@ -31,4 +43,12 @@ fun HogeScreen(
       Text(text = smokingArea.name)
     }
   }
+}
+
+@Preview
+@Composable
+internal fun HogeScreenPreview() {
+  HogeScreenContent(
+    uiState = HogeUiState.createPreview(),
+  )
 }

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeUiState.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeUiState.kt
@@ -1,5 +1,8 @@
 package app.kaito_dogi.smopin.feature.hoge
 
+import app.kaito_dogi.smopin.shared.domain.smokingArea.Latitude
+import app.kaito_dogi.smopin.shared.domain.smokingArea.Location
+import app.kaito_dogi.smopin.shared.domain.smokingArea.Longitude
 import app.kaito_dogi.smopin.shared.domain.smokingArea.SmokingArea
 
 data class HogeUiState(
@@ -7,5 +10,24 @@ data class HogeUiState(
 ) {
   companion object {
     fun createInitial(): HogeUiState = HogeUiState(smokingAreaList = emptyList())
+
+    fun createPreview(): HogeUiState = HogeUiState(
+      smokingAreaList = listOf(
+        SmokingArea(
+          name = "Shibuya Smoking Area",
+          location = Location(
+            latitude = Latitude(value = 35.6580),
+            longitude = Longitude(value = 139.7016),
+          ),
+        ),
+        SmokingArea(
+          name = "Tokyo Station Smoking Area",
+          location = Location(
+            latitude = Latitude(value = 35.6812),
+            longitude = Longitude(value = 139.7671),
+          ),
+        ),
+      ),
+    )
   }
 }

--- a/android/ui-testing/build.gradle.kts
+++ b/android/ui-testing/build.gradle.kts
@@ -1,0 +1,32 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+  alias(libs.plugins.kotlinAndroid)
+  alias(libs.plugins.androidLibrary)
+  alias(libs.plugins.compose)
+  alias(libs.plugins.composeCompiler)
+  alias(libs.plugins.paparazzi)
+}
+
+android {
+  namespace = "app.kaito_dogi.smopin.ui.testing"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig {
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+  }
+  kotlin {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_11)
+    }
+  }
+}
+
+dependencies {
+  testImplementation(projects.android.feature.hoge)
+  testImplementation(libs.junit)
+  testImplementation(libs.paparazzi)
+}

--- a/android/ui-testing/src/test/kotlin/app/kaito_dogi/smopin/ui/testing/HogeScreenPreviewTest.kt
+++ b/android/ui-testing/src/test/kotlin/app/kaito_dogi/smopin/ui/testing/HogeScreenPreviewTest.kt
@@ -1,0 +1,17 @@
+package app.kaito_dogi.smopin.ui.testing
+
+import app.cash.paparazzi.Paparazzi
+import app.kaito_dogi.smopin.feature.hoge.HogeScreenPreview
+import org.junit.Rule
+import org.junit.Test
+
+class HogeScreenPreviewTest {
+
+  @get:Rule
+  val paparazzi: Paparazzi = Paparazzi()
+
+  @Test
+  fun captureHogeScreenPreview(): Unit = paparazzi.snapshot {
+    HogeScreenPreview()
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
   alias(libs.plugins.kotlinAndroid) apply false
   alias(libs.plugins.kotlinMultiplatform) apply false
   alias(libs.plugins.metro) apply false
+  alias(libs.plugins.paparazzi) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidx-testExt = "1.3.0"
 compose = "1.9.3"
 junit = "4.13.2"
 kotlin = "2.3.0"
+paparazzi = "1.3.5"
 
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.10.0-RC"
@@ -35,6 +36,7 @@ kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serializati
 metroxAndroid = { module = "dev.zacsweers.metro:metrox-android", version.ref = "metro" }
 metroxViewModel = { module = "dev.zacsweers.metro:metrox-viewmodel", version.ref = "metro" }
 metroxViewModelCompose = { module = "dev.zacsweers.metro:metrox-viewmodel-compose", version.ref = "metro" }
+paparazzi = { module = "app.cash.paparazzi:paparazzi", version.ref = "paparazzi" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -45,3 +47,4 @@ kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
+paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ dependencyResolutionManagement {
 
 include(":android:app")
 include(":android:feature:hoge")
+include(":android:ui-testing")
 include(":shared:common")
 include(":shared:data")
 include(":shared:database:firestore")


### PR DESCRIPTION
#5 

### Motivation
- Provide a dedicated module for deterministic UI screenshot testing (VRT) using Compose Previews so visual diffs are reviewable in PRs. 
- Align with the repo modularization strategy by isolating test infrastructure from production code and reuse Compose Previews as stable snapshot sources. 

### Description
- Added a new `:android:ui-testing` module and wired it into `settings.gradle.kts` to host screenshot tests and test resources. 
- Introduced Paparazzi via the version catalog and root plugin entries and added `android/ui-testing/build.gradle.kts` to configure Paparazzi-based unit tests. 
- Refactored `HogeScreen` into a stateful composable and a stateless `HogeScreenContent` with an `@Preview` and added stable preview data via `HogeUiState.createPreview()` for deterministic snapshots. 
- Added a Paparazzi snapshot test `HogeScreenPreviewTest` and a GitHub Actions workflow `.github/workflows/vrt.yml` that runs `:android:ui-testing:verifyPaparazziDebug` on PRs and supports manual baseline recording via `recordPaparazziDebug`. 

### Testing
- Ran `./gradlew :android:ui-testing:testDebugUnitTest` which initially failed due to a Java / Kotlin toolchain version parse issue (Java 25 reported as `25.0.1`).
- Re-ran tests after selecting Java 21 and observed Gradle fail because the Android SDK location is not configured (`ANDROID_HOME` / `local.properties` missing), so unit snapshot verification could not complete in the container.
- Note: build logs also show KMP plugin deprecation warnings; the CI workflow runs `./gradlew :android:ui-testing:verifyPaparazziDebug` (configured) but will require a properly configured Android SDK on CI to succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69895305bc2483209f88b38d014b281a)