### PR TITLE
Add Kotlin Coroutines implementation/review skill and guideline

### DIFF
--- a/doc/guideline-coroutines.md
+++ b/doc/guideline-coroutines.md
@@ -1,0 +1,165 @@
+# Coroutines ガイドライン（Android / KMP）
+
+## 目的
+
+本ドキュメントは、Smopin の Android / Kotlin Multiplatform（KMP）において、Kotlin Coroutines を **再利用可能・拡張可能・テスト容易** に実装するための共通指針を定義する。
+
+`doc/strategy-modularization.md` の「再利用性を重視する」方針、および `doc/architecture-layer-data.md` の「Repository / DataSource の責務分離」を前提に、coroutine の責務とスレッド制御を明確化する。
+
+## 適用範囲
+
+- `shared` 配下（domain / data / database 実装）
+- Android UI（ViewModel, state holder）
+- 将来の iOS 側連携時に shared の suspend / Flow を利用する箇所
+
+## 設計原則
+
+## 1. 構造化並行性を守る
+
+- `GlobalScope` は使用しない。
+- 親子関係が明確な `CoroutineScope` を使う。
+- 並列実行は `coroutineScope` を第一選択とし、失敗独立性が必要な場合のみ `supervisorScope` を使う。
+
+**なぜか**
+- 画面破棄時の自動キャンセル（例: `viewModelScope`）により、不要な通信・リークを防げる。
+- KMP shared のユースケースを Android/iOS 両方から呼ぶ際も、親スコープの寿命で動作を統一できる。
+
+## 2. Dispatcher は注入する
+
+- `Dispatchers.IO` などを実装に直書きしない。
+- DataSource / UseCase / ViewModel へ `CoroutineDispatcher`（または `DispatcherProvider`）を DI する。
+
+**なぜか**
+- `doc/CONVENTION_CODING.md` の「DataSource に Dispatchers.IO をコンストラクタ注入する」規約に一致する。
+- テスト時に `TestDispatcher` へ差し替え可能となり、`runTest` で決定的に検証できる。
+
+## 3. レイヤ責務ごとに coroutine の役割を固定する
+
+### UI（Android ViewModel）
+
+- `viewModelScope.launch` を起点にする。
+- 画面状態は `StateFlow`、単発イベントは `SharedFlow` を使い分ける。
+
+### Domain（shared）
+
+- ビジネスロジックを suspend / Flow で表現する。
+- プラットフォーム依存の API を直接使わない（Dispatcher 注入経由）。
+
+### Data（Repository / DataSource）
+
+- Repository はデータ変換と集約に専念し、原則スレッド切替をしない。
+- DataSource で `withContext(ioDispatcher)` を行い I/O 境界を閉じる。
+
+**なぜか**
+- `doc/architecture-layer-data.md` の責務分離に整合。
+- レイヤごとの変更影響を局所化でき、機能追加時のリグレッション範囲を狭められる。
+
+## 実装指針
+
+## 1. API 設計
+
+- ワンショット取得: `suspend fun`
+- 継続監視: `Flow<T>`
+- 画面状態: `StateFlow<UiState>`
+
+命名は `doc/CONVENTION_CODING.md` に従い、List を返す場合は `xxxList` を明示する。
+
+## 2. Cancellation
+
+- `CancellationException` を握りつぶさない（再スローする）。
+- 長時間ループは `isActive` / `ensureActive` で協調キャンセルを維持する。
+- 中断できない後処理が必要な場合のみ `withContext(NonCancellable)` を使う。
+
+## 3. Exception
+
+- `launch`: 即時伝播（親へ）
+- `async`: `await()` 時に再送出
+- `CoroutineExceptionHandler`: 最上位でのロギング用途に限定する
+
+## 4. Flow
+
+- `flowOn` は上流責務として限定利用する。
+- `stateIn/shareIn` は購読戦略（`SharingStarted`）を明示する。
+- UI で不要な再描画が多い場合のみ `distinctUntilChanged` を付与する。
+
+## 5. テスト
+
+- `kotlinx-coroutines-test` の `runTest` を使う。
+- `StandardTestDispatcher` を基本にし、`advanceUntilIdle` で進行制御する。
+- 最低限、以下をテスト対象に含める。
+  - 正常系
+  - キャンセル
+  - 例外伝播
+  - タイムアウト / リトライ
+
+## Android 画面・ユースケース想定の実践例
+
+## 例1: 喫煙所一覧画面（Map/List）
+
+- 画面表示時、ViewModel が `viewModelScope` で `ObserveSmokingAreaListUseCase` を購読。
+- UseCase は shared domain で `Flow<List<SmokingArea>>` を返却。
+- Repository は DataSource の Flow を domain model に変換するのみ。
+
+**効果**
+- Android では Compose state 更新へ直結でき、iOS でも shared の Flow を同じ契約で再利用できる。
+
+## 例2: 喫煙所投稿（ワンショット）
+
+- ViewModel から `CreateSmokingAreaUseCase` を `suspend` で実行。
+- DataSource が `withContext(ioDispatcher)` で Firestore 書き込み。
+- 失敗時は domain エラーに変換し UI に反映。
+
+**効果**
+- 失敗ポリシーを UI へ一貫して返せる。
+- DataSource 以外の層に I/O 詳細が漏れない。
+
+## モジュール分割が coroutines 運用に与える利点
+
+`doc/strategy-modularization.md` の方針に基づき、次の効果を狙う。
+
+- **再利用性**: shared domain/data の suspend/Flow 契約を Android/iOS で共有できる。
+- **シンプルさを犠牲にして得るメリット**: Dispatcher 注入やインターフェース分離でコード量は増えるが、テスト差し替えと責務境界が明確化される。
+- **拡張性**: Firestore 以外の DataSource 追加時も UseCase 契約を保ったまま差し替え可能。
+- **テスト容易性**: レイヤ単位で TestDispatcher と Fake 実装を適用しやすい。
+- **ビルド速度**: 影響範囲がモジュール境界で限定され、変更時の再ビルドを抑制しやすい。
+
+## 採用しなかった代替案
+
+## 代替案A: Repository で `withContext(Dispatchers.IO)` を直接実施
+
+### 概要
+Repository が DataSource 呼び出し前後で I/O 切替を担う設計。
+
+### 採用しなかった理由
+- `doc/architecture-layer-data.md` の「I/O 切り替えは DataSource 責務」に反する。
+- Repository が変換・集約以外の責務を持ち、肥大化しやすい。
+- テストでスレッド制御点が分散する。
+
+### 有効になり得る条件
+- 単一モジュールの短期 PoC で、DataSource 層を分けない設計に限定する場合。
+
+## 代替案B: Dispatcher をハードコード（`Dispatchers.IO` を直書き）
+
+### 概要
+各実装クラスが直接 `Dispatchers.*` を参照する設計。
+
+### 採用しなかった理由
+- テストで差し替え困難となり、`runTest` の決定性を損なう。
+- Android 固有実装に寄り、KMP shared の移植性が低下する。
+
+### 有効になり得る条件
+- チーム規模が極小で、短期間の実験実装を最速で作る場合。
+
+## 参照資料
+
+- https://developer.android.com/kotlin/coroutines
+- https://developer.android.com/kotlin/coroutines/coroutines-adv
+- https://medium.com/androiddevelopers/easy-coroutines-in-android-viewmodelscope-25bffb605471
+- https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-exception-handler/
+- https://developer.android.com/kotlin/coroutines/test
+- https://developer.android.com/kotlin/coroutines/coroutines-best-practices
+- https://medium.com/androiddevelopers/coroutines-first-things-first-e6187bf3bb21
+- https://medium.com/androiddevelopers/cancellation-in-coroutines-aa6b90163629
+- https://medium.com/androiddevelopers/exceptions-in-coroutines-ce8da1ec060c
+- https://medium.com/androiddevelopers/coroutines-patterns-for-work-that-shouldnt-be-cancelled-e26c40f142ad
+- https://kotlinlang.org/docs/exception-handling.html

--- a/skills/kotlin-coroutines-implementation-review/SKILL.md
+++ b/skills/kotlin-coroutines-implementation-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: kotlin-coroutines-implementation-review
+description: Kotlin Coroutines の実装・設計・コードレビューを、Android/Kotlin Multiplatform（KMP）前提で一貫して実施するためのスキル。CoroutineScope設計、Dispatcher注入、Flow運用、キャンセル/例外ハンドリング、テスト（runTest, TestDispatcher）を扱うタスクで使用する。
+---
+
+# Kotlin Coroutines Implementation & Review
+
+1. `doc/guideline-coroutines.md` を最初に読み、プロジェクト規約を確認する。
+2. レイヤ単位（UI / Domain / DataSource）で coroutine の責務を分離する。
+3. 実装時は `Dispatchers` を直接参照せず、注入可能に設計する。
+4. レビュー時は `references/review-checklist.md` の順に確認する。
+5. テスト時は `kotlinx-coroutines-test` の仮想時刻制御を優先し、実時間待ちを禁止する。
+
+## Workflow
+
+### 1) Analyze
+
+- 対象コードを UI / Domain / Data のどの責務か分類する。
+- `suspend` / `Flow` / `StateFlow` / `SharedFlow` のどれが意図に一致するか判定する。
+- 呼び出しライフサイクル（画面生存期間、アプリ生存期間、永続化タスク）を明確化する。
+
+### 2) Design
+
+- **UI（Android）**: ViewModel を coroutine 起点にし、`viewModelScope` を使う。
+- **Domain（shared）**: `CoroutineDispatcher`/`DispatcherProvider` を受け取り、プラットフォーム依存を避ける。
+- **DataSource**: I/O 境界で `withContext(ioDispatcher)` を適用する（Repository では切り替えない）。
+- エラー方針（UI 表示、再試行、握りつぶし禁止）を先に定義する。
+
+### 3) Implement
+
+- 並列実行は原則 `coroutineScope` + `async`、失敗独立性が必要な場合だけ `supervisorScope`。
+- 長時間処理は協調キャンセル（`isActive`, `ensureActive`）を維持する。
+- `Flow` は cold stream を基本とし、`stateIn`/`shareIn` は必要最小限で使う。
+
+### 4) Verify
+
+- `runTest` を使用し、`StandardTestDispatcher` を標準とする。
+- `advanceUntilIdle` / `runCurrent` で進行を制御する。
+- 「キャンセル」「例外伝播」「リトライ」「タイムアウト」を必ず 1 ケース以上テストする。
+
+## Resource Loading Guide
+
+- 実装前提の詳細原則: `references/implementation-pattern.md`
+- レビュー観点チェック: `references/review-checklist.md`
+- 迷ったら先に `doc/guideline-coroutines.md` を優先し、差分のみ references を読む。

--- a/skills/kotlin-coroutines-implementation-review/references/implementation-pattern.md
+++ b/skills/kotlin-coroutines-implementation-review/references/implementation-pattern.md
@@ -1,0 +1,46 @@
+# Kotlin Coroutines 実装パターン（Android / KMP）
+
+## 1. Dispatcher
+
+- `Dispatchers.IO` / `Dispatchers.Default` / `Dispatchers.Main` を直接呼び出し側に書かない。
+- `DispatcherProvider` もしくは個別 Dispatcher を DI で注入する。
+- DataSource で I/O 切り替えを行い、Repository は変換と集約に集中する。
+
+### 推奨インターフェース例
+
+```kotlin
+interface DispatcherProvider {
+    val main: CoroutineDispatcher
+    val io: CoroutineDispatcher
+    val default: CoroutineDispatcher
+}
+```
+
+## 2. Scope ownership
+
+- 画面スコープ: `viewModelScope`
+- アプリ横断の常駐スコープ: Application/DI で明示的に管理
+- 関数内の子 coroutine: `coroutineScope` を標準採用
+
+## 3. Flow選定
+
+- 一回取得: `suspend fun`
+- 監視更新: `Flow<T>`
+- UI 状態公開: `StateFlow<UiState>`
+- 単発イベント: `SharedFlow<UiEvent>`（`replay=0` 基本）
+
+## 4. Cancellation
+
+- `catch (e: CancellationException)` を握りつぶさない。
+- `finally` でのクリーンアップは non-cancellable が必要な場合のみ `withContext(NonCancellable)` を使う。
+
+## 5. Exception
+
+- `launch` は親に例外伝播、`async` は `await()` まで遅延。
+- `CoroutineExceptionHandler` は最上位でのログ/監視用。回復ロジックには使わない。
+
+## 6. Test
+
+- `runTest` を使い、`Thread.sleep` を禁止。
+- Main dispatcher を使うコードは `Dispatchers.setMain(testDispatcher)` で置換。
+- `Flow` テストは収集キャンセル漏れを避ける。

--- a/skills/kotlin-coroutines-implementation-review/references/review-checklist.md
+++ b/skills/kotlin-coroutines-implementation-review/references/review-checklist.md
@@ -1,0 +1,37 @@
+# Kotlin Coroutines レビュー・チェックリスト
+
+## A. API 設計
+
+- [ ] ワンショット処理が `suspend fun` で定義されている
+- [ ] 連続更新が `Flow` / `StateFlow` で定義されている
+- [ ] 責務に応じて `suspend` と `Flow` が混同されていない
+
+## B. スレッドと DI
+
+- [ ] Dispatcher が注入されている（ハードコードなし）
+- [ ] DataSource で `withContext(ioDispatcher)` を適用している
+- [ ] Repository がスレッド切り替え責務を持っていない
+
+## C. 構造化並行性
+
+- [ ] `GlobalScope` を使用していない
+- [ ] 並列実行に `coroutineScope` / `supervisorScope` の意図がある
+- [ ] キャンセル時のリークがない（子 coroutine の孤児化なし）
+
+## D. 例外・キャンセル
+
+- [ ] `CancellationException` を再スローしている
+- [ ] `runCatching` 等でキャンセルを誤って成功扱いしていない
+- [ ] 例外のユーザー体験（再試行、表示、ログ）が定義されている
+
+## E. Flow 運用
+
+- [ ] `flowOn` の適用位置が妥当（上流のみ）
+- [ ] `stateIn` / `shareIn` の `started` 戦略が妥当
+- [ ] 不要な `distinctUntilChanged` や過剰な `buffer` がない
+
+## F. テスト
+
+- [ ] `runTest` を使用している
+- [ ] 仮想時刻 API (`advanceUntilIdle` 等) を使っている
+- [ ] キャンセル、例外、タイムアウトのケースがある


### PR DESCRIPTION
### Motivation
- Issue #25 に対応して、Android / KMP を前提とした Kotlin Coroutines の実装方針とレビュー用リソースを整備するため。 
- 既存の `doc/` 方針（`doc/architecture-layer-data.md`, `doc/strategy-modularization.md`, `doc/CONVENTION_CODING.md`）と整合しつつ、Dispatcher 注入・レイヤ責務分離・テスト容易性を担保する設計を明文化するため。 

### Description
- `doc/guideline-coroutines.md` を追加し、設計原則（構造化並行性、Dispatcher 注入、レイヤごとの責務、Cancellation/Exception/Flow 運用、テスト方針）と実際の画面ユースケース（喫煙所一覧・投稿）を記述した。 
- `skills/kotlin-coroutines-implementation-review/SKILL.md` を追加し、Skill トリガー・ワークフロー（Analyze/Design/Implement/Verify）と参照順序を定義した。 
- Skill の参照資料として `references/implementation-pattern.md`（実装パターン）と `references/review-checklist.md`（レビュー観点チェックリスト）を追加し、レビュー/実装時に再利用できる形式で整理した。 
- 変更はコミット済みで PR を作成しており、リポジトリに新規ファイルが追加されている。 

### Testing
- `python /opt/codex/skills/.system/skill-creator/scripts/quick_validate.py skills/kotlin-coroutines-implementation-review` を実行したが、実行環境に `yaml` モジュールが未導入のため `ModuleNotFoundError: No module named 'yaml'` で検証は失敗した。 
- 変更ファイルは `git add`/`git commit` によりコミットされ、コミット操作は成功した。 
- PR 作成手順（`mcp__make_pr__make_pr`）を実行して PR を作成済みであり、PR の本文に検証結果を記載した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f147e2f3c832091008f5f8f0d61e9)