### PR TITLE
Kotlin Coroutines 実装・レビュー用 Skill とガイドラインを追加 (#25)

### DIFF
--- a/doc/guideline-coroutines.md
+++ b/doc/guideline-coroutines.md
@@ -1,0 +1,201 @@
+# Kotlin Coroutines ガイドライン
+
+## 目的
+
+本ドキュメントは、Android / Kotlin Multiplatform（KMP）を前提としたアプリ開発で、Kotlin Coroutines を安全かつ一貫して実装・レビューするための判断基準を定義する。
+
+> 注記: 本ドキュメントは汎用ガイドとして記述する。プロジェクト固有のレイヤ設計・モジュール設計へ適用するときは `doc/strategy-modularization.md`、`doc/architecture-layer-data.md`、`doc/strategy-dependency-injection.md` の規約を優先してマッピングする。
+
+---
+
+## 1. 設計原則（Why）
+
+### 1-1. Structured Concurrency を優先する理由
+
+- 親子関係のあるジョブ管理により、キャンセルと例外伝播が予測可能になる。
+- Android の画面ライフサイクル（`ViewModel` の生存期間）と自然に整合し、メモリリークや孤立ジョブを避けられる。
+- KMP shared ロジックでも同じルールで運用でき、Android/iOS で挙動差が出にくい。
+
+### 1-2. Dispatcher 注入を優先する理由
+
+- テスト時に `StandardTestDispatcher` へ置換し、並行処理を決定論的に検証できる。
+- I/O 境界を DataSource 側に閉じ込めることで責務を明確化できる。
+- Android 端末依存のスケジューリング差を吸収しやすい。
+
+### 1-3. Flow と suspend の使い分けを明確化する理由
+
+- API 契約が明確になり、呼び出し側が「一回取得」か「継続監視」かを誤解しない。
+- UI 層で `stateIn` / `shareIn` を選定しやすく、再購読や画面回転時の挙動が安定する。
+
+---
+
+## 2. レイヤ別ガイド
+
+## 2-1. UI 層（Android 画面 / StateHolder）
+
+### 方針
+
+- 画面イベント起点の処理は `viewModelScope.launch` で実行する。
+- `Flow` を `StateFlow` に変換する際、`SharingStarted.WhileSubscribed(timeout)` を基本とする。
+- UI 表示に必要な状態は単一の `UiState` に集約し、ロード中・成功・失敗を表現する。
+
+### 実装イメージ
+
+- 例: 検索画面で、キーワード入力を `debounce` し、`flatMapLatest` で最新検索のみ有効化。
+- 例: 地図画面で現在地更新を購読し、画面非表示時は収集停止。
+
+### 禁止事項
+
+- `GlobalScope` 利用
+- `Dispatchers.IO` の ViewModel 直書き
+- `launch` 内で例外を握りつぶして UI 状態を更新しない実装
+
+## 2-2. Domain 層（UseCase / Repository interface）
+
+### 方針
+
+- UseCase はユースケース単位で `suspend` または `Flow` を返し、スレッド戦略を隠蔽する。
+- 「複数 Repository 呼び出しを束ねる」責務は UseCase に置く。
+- 失敗時の方針（即失敗/部分成功許容）を `coroutineScope` / `supervisorScope` で明示する。
+
+### 実装イメージ
+
+- 例: ユーザー詳細画面で `User` と `Badge` を並列取得。`User` は必須、`Badge` は任意。
+- 例: 保存操作後に分析イベントを送る場合、保存成功を優先し分析イベント失敗はログ化。
+
+## 2-3. Data 層（Repository 実装 / DataSource 実装）
+
+### 方針
+
+- DataSource で `withContext(ioDispatcher)` を用いて I/O 切り替えを行う。
+- Repository はモデル変換とデータ統合に集中し、ビジネスルールは持たない。
+- `CancellationException` を握りつぶさない。
+
+### 実装イメージ
+
+- 例: `UserRepository.getUserList()` は NetworkDataSource の結果をドメインモデルへ変換。
+- 例: `UserRepository.observeUser(userId)` は Disk/Remote の Flow を統合。
+
+---
+
+## 3. 例外処理・キャンセル
+
+## 3-1. 基本原則
+
+- `launch` の例外は親へ伝播する。
+- `async` の例外は `await()` 時に表面化する。
+- `CoroutineExceptionHandler` は最終ハンドラであり、復旧ロジックは別途明示する。
+
+## 3-2. キャンセル
+
+- キャンセルは正常系制御の一部として扱う。
+- `runCatching` 使用時は `CancellationException` を再 throw する。
+- 長時間ループは `ensureActive()` で協調キャンセルを実装する。
+
+## 3-3. 完遂が必要な処理
+
+- 投稿・送信など「途中中断が不正」な処理は、画面スコープでなくアプリスコープで実行する。
+- ただし無制限再試行は避け、上限回数・指数バックオフ・打ち切り条件を定義する。
+
+---
+
+## 4. Flow 運用
+
+### 演算子選定ルール
+
+- `flatMapLatest`: 最新入力のみ有効（検索、フィルタ）
+- `combine`: 複数状態の合成（設定 + データ）
+- `debounce`: 高頻度入力の抑制（テキスト入力）
+- `distinctUntilChanged`: 重複再描画防止
+
+### Hot Flow 化
+
+- 画面表示状態を持つ場合は `stateIn` を使う。
+- イベント配信（1回消費）には `SharedFlow` を使う。
+- バッファサイズと `replay` は最小限にする。
+
+---
+
+## 5. テスト戦略
+
+### 必須セット
+
+- `runTest`
+- `MainDispatcher` 差し替えルール
+- 仮想時間 API（`advanceTimeBy`, `advanceUntilIdle`）
+
+### テスト観点
+
+- 成功パス
+- 失敗パス
+- キャンセルパス
+- 時間依存演算子（`debounce`, `timeout`）
+
+### 具体例（Android 画面）
+
+- 検索画面: 連続入力時に最後のキーワードだけで API 呼び出しされること。
+- 詳細画面: 画面離脱時に収集ジョブが確実に停止すること。
+
+### 具体例（KMP shared ロジック）
+
+- 共有 UseCase の並列取得ロジックで、片方失敗時の挙動が仕様通りであること。
+- iOS 連携時に Flow 変換後の状態更新順序が変わらないこと。
+
+---
+
+## 6. レビュー観点（短縮版）
+
+- スコープ境界: `viewModelScope` / アプリスコープの使い分けが妥当か
+- Dispatcher: 直書きがなく注入されているか
+- 例外: `CancellationException` が正しく伝播するか
+- Flow: 演算子選定に意図があるか
+- テスト: 時間依存・キャンセルを含めて検証しているか
+
+---
+
+## 7. 代替案との比較
+
+## 代替案 A: 単純なコールバック + Executor ベース
+
+### 概要
+
+Coroutines/Flow を使わず、コールバックで非同期処理を接続する。
+
+### 採用しなかった理由
+
+- 例外伝播とキャンセル伝播が分断され、UI・Domain・Data を跨ぐ制御が煩雑になる。
+- KMP shared で Android/iOS 間の非同期契約を揃えにくい。
+
+### 有効になり得る条件
+
+- 短期の PoC で非同期パターンがごく少ない場合。
+- 既存ライブラリ都合で Coroutines 導入コストが過大な場合。
+
+## 代替案 B: すべて suspend に統一し Flow を使わない
+
+### 概要
+
+継続監視用途も含めて都度 `suspend` 再取得で実装する。
+
+### 採用しなかった理由
+
+- 状態監視の表現力が落ち、再購読や差分更新の効率が悪化する。
+- 画面回転・復帰時の再取得戦略が分散し、State 管理が複雑化する。
+
+### 有効になり得る条件
+
+- 更新頻度が非常に低く、単発 API 取得のみで成立する管理画面。
+- MVP 初期で状態監視要件が存在しない場合。
+
+---
+
+## 8. プロジェクト文脈への適用メモ
+
+以下の既存方針と整合させる。
+
+- DataSource で I/O を切り替える（`doc/CONVENTION_CODING.md`）
+- Repository を SSOT とし、Repository にビジネスロジックを置かない（`doc/architecture-layer-data.md`）
+- モジュール境界を維持し、依存性逆転を崩さない（`doc/strategy-modularization.md`）
+- Dispatcher やスコープ提供を DI で切り替え可能にする（`doc/strategy-dependency-injection.md`）
+
+この整合を維持することで、再利用性・拡張性・テスト容易性・ビルド最適化の各利点を、Coroutines 実装でも一貫して享受できる。

--- a/skills/kotlin-coroutines-implementation-review/SKILL.md
+++ b/skills/kotlin-coroutines-implementation-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: kotlin-coroutines-implementation-review
+description: Android/Kotlin Multiplatform で Kotlin Coroutines を実装・レビューするための実践スキル。Repository/DataSource/ViewModel/UseCase の責務ごとの Dispatcher 設計、Structured Concurrency、キャンセル、例外処理、Flow 運用、テスト戦略を一貫して適用したいときに使う。
+---
+
+# Kotlin Coroutines 実装・レビュー手順
+
+以下を順番に実施する。
+
+## 1) 変更対象を責務ごとに分類する
+
+- UI 層（Compose/SwiftUI と接続する StateHolder）
+- Domain 層（UseCase, Repository interface）
+- Data 層（Repository 実装, DataSource 実装）
+
+分類時点で次を明確化する。
+
+- 呼び出し元が「一回取得（suspend）」か「継続監視（Flow）」か
+- キャンセル可能であるべき処理か、完遂が必要な処理か
+- 例外を UI へ伝播するか、Result 型に変換するか
+
+## 2) スコープ境界を固定する
+
+- `ViewModel` では `viewModelScope` を使う
+- ライフサイクル境界を超える処理は `applicationScope` 相当を明示的に使う
+- `GlobalScope` は使わない
+
+設計判断:
+
+- 画面離脱で止めるべき処理: `viewModelScope`
+- 送信・保存など完遂優先処理: 依存注入した外部スコープ + `supervisorScope`
+
+## 3) Dispatcher を注入する
+
+- DataSource で `withContext(ioDispatcher)` を使う
+- CPU バウンド処理は `defaultDispatcher`
+- Main 固定処理以外で `Dispatchers.IO` などを直書きしない
+
+## 4) Structured Concurrency を守る
+
+- 並列実行は `coroutineScope { async { ... } }` で親子関係を保持する
+- 子失敗時の方針を明示する
+  - 全体失敗: `coroutineScope`
+  - 部分成功許容: `supervisorScope` + 個別ハンドリング
+
+## 5) Flow 契約を明示する
+
+- Repository API で「状態監視」は `Flow<T>`
+- 使う演算子の意図をコメントまたは命名で残す
+  - 入力追従: `flatMapLatest`
+  - 同時収集: `combine`
+  - 重複削減: `distinctUntilChanged`
+  - 高頻度入力抑制: `debounce`
+- `flowOn` は「上流の重い処理」だけに適用する
+
+## 6) キャンセル協調を入れる
+
+- 長いループや I/O 直前で `ensureActive()` / `isActive` を使う
+- `CancellationException` を握りつぶさない
+- `runCatching` 利用時は `CancellationException` を再 throw する
+
+## 7) 例外処理ポリシーを統一する
+
+- `launch` と `async` の例外伝播差を意識する
+- 末端 UI イベントは `CoroutineExceptionHandler` か ViewModel 内のエラーステートで吸収する
+- Domain/Data で recover できない例外は握りつぶさず上位に伝える
+
+## 8) テストを先に固定する
+
+- `runTest` + `TestDispatcher` を使う
+- `MainDispatcherRule` 相当で Main を差し替える
+- Flow 検証は `first`, `toList`, `Turbine` 等で期待値を明示する
+- 時間依存演算子は仮想時間（`advanceTimeBy`, `advanceUntilIdle`）で検証する
+
+## 9) レビュー時の最終チェック
+
+`references/review-checklist.md` を使用し、全項目を確認する。
+
+## 出力フォーマット（レビューコメントテンプレート）
+
+- `重大`: アプリクラッシュ、データ欠損、キャンセル不整合
+- `重要`: スコープ誤り、Dispatcher 直書き、例外ポリシー不一致
+- `改善`: 命名、演算子選定、テスト不足
+
+コメント形式:
+
+1. 事象（何が起きるか）
+2. 原因（Coroutine の原則上なぜ問題か）
+3. 修正案（最小変更での提案コード）
+4. 影響範囲（UI/Domain/Data, Android/iOS/KMP）
+
+## 代表スニペット
+
+具体例は `references/snippets.md` を参照する。

--- a/skills/kotlin-coroutines-implementation-review/references/review-checklist.md
+++ b/skills/kotlin-coroutines-implementation-review/references/review-checklist.md
@@ -1,0 +1,37 @@
+# Kotlin Coroutines レビュー・チェックリスト
+
+## スコープ
+- [ ] `GlobalScope` を使用していない
+- [ ] 画面ライフサイクル処理は `viewModelScope` を使っている
+- [ ] 完遂が必要な処理は外部スコープを明示している
+
+## Dispatcher
+- [ ] DataSource で `withContext(ioDispatcher)` を使用している
+- [ ] `Dispatchers.IO/Default/Main` の直書きがない（DI 例外を除く）
+- [ ] CPU バウンド処理と I/O バウンド処理を分離している
+
+## Structured Concurrency
+- [ ] 並列処理で `coroutineScope` / `supervisorScope` を意図的に使い分けている
+- [ ] `async` の `await` 漏れがない
+- [ ] 子コルーチン失敗時の期待挙動が定義されている
+
+## キャンセル
+- [ ] `CancellationException` を握りつぶしていない
+- [ ] `runCatching` 内でキャンセルを再 throw している
+- [ ] 長時間処理がキャンセル協調している
+
+## 例外処理
+- [ ] `launch` と `async` の例外伝播差を理解した実装になっている
+- [ ] UI で表示すべきエラーとログ送信のみのエラーを区別している
+- [ ] リトライ方針（回数、間隔、打ち切り条件）が明示されている
+
+## Flow
+- [ ] ワンショット取得を Flow にしていない（不要な場合）
+- [ ] `stateIn/shareIn` の started 戦略が妥当
+- [ ] `flatMapLatest/combine/debounce/distinctUntilChanged` の選定意図が説明可能
+
+## テスト
+- [ ] `runTest` を使用している
+- [ ] Main Dispatcher をテストで差し替えている
+- [ ] 時間依存処理を仮想時間で検証している
+- [ ] 成功・失敗・キャンセルの 3 パスを検証している

--- a/skills/kotlin-coroutines-implementation-review/references/snippets.md
+++ b/skills/kotlin-coroutines-implementation-review/references/snippets.md
@@ -1,0 +1,79 @@
+# Kotlin Coroutines 代表スニペット
+
+## 1. Dispatcher 注入
+
+```kotlin
+class UserNetworkDataSource(
+  private val ioDispatcher: CoroutineDispatcher,
+) {
+  suspend fun getUserList(): List<UserDataModel> = withContext(ioDispatcher) {
+    // network call
+    emptyList()
+  }
+}
+```
+
+## 2. キャンセルを壊さない Result 変換
+
+```kotlin
+suspend fun <T> safeCall(block: suspend () -> T): Result<T> =
+  try {
+    Result.success(block())
+  } catch (throwable: Throwable) {
+    if (throwable is CancellationException) throw throwable
+    Result.failure(throwable)
+  }
+```
+
+## 3. 並列実行と失敗方針の明示
+
+```kotlin
+suspend fun loadUserAndBadge(
+  userRepository: UserRepository,
+  badgeRepository: BadgeRepository,
+): Pair<User, Badge?> = supervisorScope {
+  val userDeferred = async { userRepository.getUser() }
+  val badgeDeferred = async {
+    runCatching { badgeRepository.getBadge() }.getOrNull()
+  }
+  userDeferred.await() to badgeDeferred.await()
+}
+```
+
+## 4. ViewModel での Flow 変換
+
+```kotlin
+val uiState: StateFlow<UserUiState> = query
+  .debounce(300)
+  .distinctUntilChanged()
+  .flatMapLatest { keyword -> repository.observeUserList(keyword) }
+  .map { users -> UserUiState(users = users, isLoading = false) }
+  .stateIn(
+    scope = viewModelScope,
+    started = SharingStarted.WhileSubscribed(5_000),
+    initialValue = UserUiState(isLoading = true),
+  )
+```
+
+## 5. runTest で時間検証
+
+```kotlin
+@Test
+fun debounceの後に最新入力のみが反映される() = runTest {
+  val resultList = mutableListOf<String>()
+  val flow = MutableSharedFlow<String>(extraBufferCapacity = 10)
+
+  val job = launch {
+    flow.debounce(300).collect(resultList::add)
+  }
+
+  flow.emit("u")
+  flow.emit("us")
+  flow.emit("use")
+  advanceTimeBy(300)
+  advanceUntilIdle()
+
+  assertEquals(listOf("use"), resultList)
+  job.cancel()
+}
+```


### PR DESCRIPTION
### Motivation

- Android / Kotlin Multiplatform を前提に、Coroutines の実装とコードレビューで再利用できる実践的な手順とチェックリストを提供するために追加しました。 
- 実装上の方針（Dispatcher 注入、Structured Concurrency、キャンセル、例外、Flow、テスト）をチーム間で一貫して適用できるようにする目的です。 
- 既存の `doc/` 方針（モジュール化、レイヤ設計、DI 方針）と整合させつつ、レビュー作業を効率化するためです。

### Description

- `doc/guideline-coroutines.md` を新規作成し、設計原則（Why）、UI/Domain/Data 各レイヤの実装方針、例外/キャンセル、Flow 運用、テスト戦略、代替案比較、既存ドキュメントとの適用メモを体系化しました。 
- Skill を `skills/kotlin-coroutines-implementation-review/` に追加し、`SKILL.md` に実装・レビュー手順（責務分類→スコープ→Dispatcher→Structured Concurrency→Flow→キャンセル/例外→テスト→レビュー）とレビューコメントテンプレートを定義しました。 
- Skill の補助資料として `references/review-checklist.md`（レビューのチェックリスト）と `references/snippets.md`（代表スニペット：Dispatcher 注入、キャンセル安全な Result 変換、supervisorScope 例、Flow/stateIn、runTest 時の時間検証）を追加しました。 

### Testing

- 差分整合性チェックとして `git diff --check` を実行し、エラーは報告されませんでした。 
- リポジトリ状態確認として `git status --short` を実行し、追加ファイルが作業ツリーにあることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f16beb1e083209826b7786b55894a)