### PR TITLE
Kotlin Coroutines 実装/レビュー Skill とガイドラインを追加

### DIFF
--- a/doc/guideline-coroutines.md
+++ b/doc/guideline-coroutines.md
@@ -1,0 +1,204 @@
+# Kotlin Coroutines ガイドライン
+
+## 目的
+
+本ドキュメントは、Smopin の Android / KMP / iOS 連携において Kotlin Coroutines を一貫した設計で実装・レビューするための基準を示す。
+
+合わせて、以下の既存方針を Coroutines 設計に接続する。
+
+- `doc/strategy-modularization.md`
+- `doc/strategy-dependency-injection.md`
+- `doc/architecture-layer-data.md`
+- `doc/CONVENTION_CODING.md`
+
+## なぜこの設計なのか
+
+Smopin ではモジュール分割の優先順位として **再利用性 > シンプルさ > その他利点（拡張性・テスト容易性・ビルド速度）** を採用している。
+そのため Coroutines も「短く書けるか」より「責務境界を越えても破綻しないか」を優先する。
+
+具体的には次を重視する。
+
+1. **レイヤごとに Coroutine の責務を固定**し、再利用時の認知負荷を下げる
+2. **Dispatcher と Scope の注入**でテスト可能性を確保する
+3. **構造化並行性とキャンセル協調**で画面破棄・アプリ遷移時の不整合を防ぐ
+
+この方針は、KMP shared で共通化したデータ取得処理を Android ViewModel と iOS 側購読の双方で安全に扱うために必要。
+
+## レイヤ別ガイドライン
+
+### UI レイヤ（Android 例: `HogeScreen` / `HogeViewModel`）
+
+#### 役割
+
+- 画面イベントを受けて UseCase/Repository を呼ぶ
+- `StateFlow<UiState>` を公開し UI は購読に専念する
+- 画面ライフサイクルに従って処理を開始・キャンセルする
+
+#### 実装指針
+
+- `viewModelScope` 以外のグローバルスコープは使わない
+- 例外は UI 表示に必要な形へ変換するが、`CancellationException` は再送出する
+- Flow を `stateIn` する場合、`SharingStarted` を明示する
+
+### ドメインレイヤ（UseCase / ドメインモデル）
+
+#### 役割
+
+- ビジネスルールの合成
+- エラー分類（ドメイン観点の意味づけ）
+
+#### 実装指針
+
+- `suspend` / `Flow` の選択理由を API で表現する
+- 並列実行が必要な場合は `coroutineScope` を基本とする
+- 部分成功を許容する場合のみ `supervisorScope` を使う
+
+### データレイヤ（Repository / DataSource）
+
+#### 役割
+
+- Repository: DataSource の統合、ドメイン変換
+- DataSource: 外部 SDK / API の隠蔽、I/O 実行
+
+#### 実装指針
+
+- DataSource 実装は `withContext(ioDispatcher)` を必須とする
+- `Dispatchers.IO` を直参照せず、DI で注入する
+- データレイヤでエラーを握りつぶさない（`architecture-layer-data.md` 準拠）
+
+## 処理種別ごとの Scope 戦略
+
+### UI 指向
+
+- 例: 喫煙所一覧画面で初回ロード
+- Scope: `viewModelScope`
+- 理由: 画面離脱時は処理継続価値が低く、キャンセルが正しい
+
+### アプリケーション指向
+
+- 例: バックグラウンド同期間隔で喫煙所キャッシュ更新
+- Scope: Repository に注入した `CoroutineScope`
+- 理由: 画面に依存しないため、画面破棄で中断しない
+
+### ビジネス指向
+
+- 例: 必達の投稿再送、利用規約同意ログ送信
+- Scope: WorkManager など OS 管理のジョブ
+- 理由: プロセス死後も継続が必要
+
+## API 設計規約
+
+- ワンショット取得: `suspend fun getXxxList()`
+- 監視取得: `fun observeXxxList(): Flow<List<Xxx>>`
+- List 返却は命名に `List` を明示（`CONVENTION_CODING.md` 準拠）
+
+## エラーハンドリング規約
+
+1. DataSource: 例外をそのまま伝播（ログ最小限）
+2. Repository/UseCase: 失敗の意味をドメインへ寄せる
+3. ViewModel: 画面表示可能な `UiState` に落とす
+
+補足:
+
+- `CoroutineExceptionHandler` は root coroutine でのみ有効
+- `async` の例外は `await` まで遅延するため、回収漏れを禁止
+
+## キャンセル規約
+
+- `catch` で `CancellationException` を検知したら再送出
+- リソース解放は `finally` で実施
+- キャンセル不可の後処理が必要な場合のみ `NonCancellable` を使う
+
+## テスト規約
+
+### 基本
+
+- `runTest` と `StandardTestDispatcher` を使用
+- 時間依存は `advanceTimeBy` / `advanceUntilIdle` で制御
+- 失敗系（例外・キャンセル）を最低 1 ケース入れる
+
+### Android 画面ユースケース例
+
+- ケース: `HogeViewModel` が `onStart` で喫煙所一覧取得
+- 観点:
+  - 成功時に `UiState` が更新される
+  - 失敗時にエラー文言が設定される
+  - ViewModel 破棄時に処理がキャンセルされる
+
+### KMP shared ロジック例
+
+- ケース: `shared:data` の Repository が `shared:database:firestore` から取得
+- 観点:
+  - DataSource の Dispatcher が注入で差し替え可能
+  - Mapper 変換が常に通る
+  - 例外が握りつぶされずドメインまで到達する
+
+## マルチモジュール分割が Coroutines に与える効果
+
+### 再利用性
+
+- `shared:data` の Coroutine 実装を Android/iOS 双方で使える
+- Dispatcher 注入ルールを共通化すると、プラットフォーム差分を実装に漏らさない
+
+### シンプルさを犠牲にしてでも得られるメリット
+
+- Scope 注入・Mapper 分離・Repository/DataSource 分離でコード量は増える
+- ただし以下が得られる:
+  - 実装の置換容易性（Firestore → 別 backend）
+  - AI/人間のレビュー観点の定型化
+  - 大規模化時の破綻回避
+
+### その他利点
+
+- **拡張性**: 新しい機能モジュール追加時に Coroutine 責務を転用可能
+- **テスト容易性**: 各層で TestDispatcher/Fake を差し込める
+- **ビルド速度**: 変更影響範囲をモジュール単位で局所化できる
+
+## 採用しなかった代替案
+
+### 代替案 1: ViewModel から DataSource まで直接呼び出し（Repository 省略）
+
+#### 概要
+
+- 小規模構成として、UI → DataSource へ直結し `suspend` 呼び出しのみで実装する
+
+#### 採用しなかった理由
+
+- モジュール戦略の「依存性逆転」「再利用性」と矛盾する
+- 例外方針・変換責務が UI に漏れ、レビュー軸が崩れる
+
+#### 有効になり得る条件
+
+- PoC で寿命が短い
+- 機能が 1 画面のみで shared 化しない
+- チーム 1 人で短期間検証する
+
+### 代替案 2: DataSource 内で例外吸収し `Result` を返す
+
+#### 概要
+
+- I/O 境界で `runCatching` し、常に `Result<T>` を返す
+
+#### 採用しなかった理由
+
+- データレイヤの責務肥大化（UI 都合のエラー分類が混入）
+- 既存方針「データレイヤでエラーをキャッチしない」に反する
+
+#### 有効になり得る条件
+
+- 外部 SDK が壊れやすく、データ層でリトライ戦略を統一したい
+- ドメインが極小で、エラー型の厳密設計より実装速度を優先する
+
+## 参照
+
+- https://developer.android.com/kotlin/coroutines
+- https://developer.android.com/kotlin/coroutines/coroutines-adv
+- https://medium.com/androiddevelopers/easy-coroutines-in-android-viewmodelscope-25bffb605471
+- https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-exception-handler/
+- https://developer.android.com/kotlin/coroutines/test
+- https://developer.android.com/kotlin/coroutines/coroutines-best-practices
+- https://medium.com/androiddevelopers/coroutines-first-things-first-e6187bf3bb21
+- https://medium.com/androiddevelopers/cancellation-in-coroutines-aa6b90163629
+- https://medium.com/androiddevelopers/exceptions-in-coroutines-ce8da1ec060c
+- https://medium.com/androiddevelopers/coroutines-patterns-for-work-that-shouldnt-be-cancelled-e26c40f142ad
+- https://kotlinlang.org/docs/exception-handling.html

--- a/doc/skills/kotlin-coroutines-implementation-review/SKILL.md
+++ b/doc/skills/kotlin-coroutines-implementation-review/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: kotlin-coroutines-implementation-review
+description: Android/KMP プロジェクトで Kotlin Coroutines を実装またはレビューするときに、構造化並行性・キャンセル・例外・テスト・Dispatcher 注入の観点で設計判断を支援する。
+---
+
+# Kotlin Coroutines 実装・レビュー Skill
+
+## この Skill を使う場面
+
+- ViewModel / UseCase / Repository / DataSource に `suspend` / `Flow` / `CoroutineScope` を導入する
+- 既存実装のレビューで、キャンセル安全性・例外伝播・Dispatcher の責務境界を確認する
+- KMP shared で共通化したロジックを Android / iOS 双方で安全に扱う
+
+## 使い方（最小手順）
+
+1. 対象コードが UI 指向 / アプリケーション指向 / ビジネス指向のどれかを判定する。
+2. `references/checklist.md` のチェックリストで責務分離を検証する。
+3. 実装・修正が必要なら `references/patterns.md` のテンプレートをベースに最小変更で反映する。
+4. `kotlinx-coroutines-test` でキャンセル・例外・Dispatcher 差し替えをテストする。
+
+## 判断原則
+
+- **構造化並行性優先**：`launch` / `async` を呼ぶスコープ所有者を明示し、子コルーチンの寿命を親に従属させる。
+- **責務境界優先**：
+  - UI レイヤは画面ライフサイクルと状態管理を担当
+  - data レイヤは I/O と変換のみ担当（例外の握りつぶし禁止）
+- **Dispatcher 注入優先**：`Dispatchers.IO` などの直参照を避け、テストで差し替え可能にする。
+- **キャンセル協調優先**：`CancellationException` を握りつぶさず再送出し、`finally` でクリーンアップする。
+
+## 禁止事項
+
+- `GlobalScope` の利用
+- DataSource/Repository での無根拠な `supervisorScope` 常用
+- `flow {}` 内で別スコープに `launch` して emit 競合を作る実装
+- `runBlocking` の本番コード利用
+
+## 参照
+
+- 実装・レビュー観点: `references/checklist.md`
+- 典型パターン: `references/patterns.md`

--- a/doc/skills/kotlin-coroutines-implementation-review/references/checklist.md
+++ b/doc/skills/kotlin-coroutines-implementation-review/references/checklist.md
@@ -1,0 +1,47 @@
+# Coroutines 実装・レビュー チェックリスト
+
+## 1. レイヤ責務
+
+- [ ] ViewModel では `viewModelScope` を使い、画面離脱時に不要処理がキャンセルされる
+- [ ] UseCase はビジネスルールの合成に集中し、UI 状態や SDK 依存を持たない
+- [ ] Repository は複数 DataSource の統合とドメイン変換を担当する
+- [ ] DataSource は I/O と外部依存の隠蔽に限定され、`withContext(ioDispatcher)` で実行される
+
+## 2. API 形状
+
+- [ ] ワンショット読み取りは `suspend fun`
+- [ ] 監視系は `Flow<T>`
+- [ ] `Flow` の hot/cold を呼び出し側責務に合わせて明示 (`stateIn`, `shareIn`)
+- [ ] `suspend` と `Flow` を混在させるとき、責務理由が KDoc/コメントで説明されている
+
+## 3. キャンセル
+
+- [ ] `catch` で `CancellationException` を再送出している
+- [ ] 長時間処理で `isActive` / `ensureActive` を使って協調キャンセルしている
+- [ ] リソース解放は `finally` で実施し、必要なら `withContext(NonCancellable)` を使う
+
+## 4. 例外
+
+- [ ] 例外は「発生箇所でログ」「変換は境界で最小限」「UI 文言は UI 側」で分離
+- [ ] `CoroutineExceptionHandler` は root coroutine でのみ利用している
+- [ ] `async` の例外は `await()` で回収される設計になっている
+- [ ] 並列子タスクの失敗戦略（全体失敗 or 部分継続）が `coroutineScope` / `supervisorScope` で明示されている
+
+## 5. Dispatcher / Scope 注入
+
+- [ ] `AppDispatcher` などの qualifier で Dispatcher を注入
+- [ ] Repository のアプリケーション指向処理に必要な場合のみ外部 `CoroutineScope` を注入
+- [ ] `Dispatchers.Default/IO/Main` の直参照がテスト不可能な箇所に残っていない
+
+## 6. テスト
+
+- [ ] `runTest` + `StandardTestDispatcher` を使用
+- [ ] `advanceUntilIdle` / `advanceTimeBy` で時間依存処理を決定的に検証
+- [ ] Flow テストで `first`, `toList`, Turbine 等を利用し、キャンセル時の挙動も確認
+- [ ] 失敗ケース（例外、タイムアウト、キャンセル）を少なくとも 1 ケース含む
+
+## 7. Android / KMP 実務観点
+
+- [ ] Android: ViewModel が `StateFlow<UiState>` を公開し、UI は collect のみ行う
+- [ ] shared: `expect/actual` を使う場合、Dispatcher/時刻/ネットワーク境界を抽象化する
+- [ ] iOS 連携: 長寿命 Flow をブリッジする際、購読解除時のキャンセル経路が定義されている

--- a/doc/skills/kotlin-coroutines-implementation-review/references/patterns.md
+++ b/doc/skills/kotlin-coroutines-implementation-review/references/patterns.md
@@ -1,0 +1,82 @@
+# Coroutines 典型パターン
+
+## A. DataSource: Dispatcher 注入 + withContext
+
+```kotlin
+internal class DefaultSmokingAreaNetworkDataSource(
+  @param:AppDispatcher(dispatcher = AppDispatchers.IO)
+  private val ioDispatcher: CoroutineDispatcher,
+  private val api: SmokingAreaApi,
+) : SmokingAreaNetworkDataSource {
+  override suspend fun getSmokingAreaDataModelList(): List<SmokingAreaDataModel> =
+    withContext(context = ioDispatcher) {
+      api.getSmokingAreaResponseList().map(transform = SmokingAreaMapper::toDataModel)
+    }
+}
+```
+
+## B. ViewModel: UI 指向の収集
+
+```kotlin
+class HogeViewModel(
+  private val getSmokingAreaListUseCase: GetSmokingAreaListUseCase,
+) : ViewModel() {
+  private val _uiState = MutableStateFlow(HogeUiState())
+  val uiState: StateFlow<HogeUiState> = _uiState
+
+  fun onStart() {
+    viewModelScope.launch {
+      getSmokingAreaListUseCase()
+        .onSuccess { smokingAreaList ->
+          _uiState.update { state -> state.copy(smokingAreaList = smokingAreaList) }
+        }
+        .onFailure { throwable ->
+          if (throwable is CancellationException) throw throwable
+          _uiState.update { state -> state.copy(errorMessage = throwable.message) }
+        }
+    }
+  }
+}
+```
+
+## C. Repository: アプリケーション指向処理
+
+```kotlin
+class RefreshSmokingAreaRepository(
+  private val networkDataSource: SmokingAreaNetworkDataSource,
+  private val appScope: CoroutineScope,
+) {
+  suspend fun refresh(): Unit =
+    appScope.launch {
+      networkDataSource.getSmokingAreaDataModelList()
+      // 保存処理
+    }.join()
+}
+```
+
+- 呼び出し元の画面が破棄されても継続すべき処理のみ適用する。
+- 値を返す場合は `async/await` を使う。
+
+## D. テスト: runTest + TestDispatcher
+
+```kotlin
+@Test
+fun `refresh success updates cache`() = runTest {
+  val testDispatcher = StandardTestDispatcher(testScheduler)
+  val repository = RefreshSmokingAreaRepository(
+    networkDataSource = FakeSmokingAreaNetworkDataSource(),
+    appScope = CoroutineScope(testDispatcher + SupervisorJob()),
+  )
+
+  repository.refresh()
+  advanceUntilIdle()
+
+  assertTrue(repository.hasCache())
+}
+```
+
+## E. 例外戦略の使い分け
+
+- `coroutineScope`: 子の失敗で兄弟を全キャンセル（整合性重視）
+- `supervisorScope`: 子の失敗を局所化（部分成功許容）
+- `CoroutineExceptionHandler`: root coroutine の最終フォールバック


### PR DESCRIPTION
### Motivation
- Issue #25 の受け入れ条件に沿って、Android / KMP プロジェクトでの Kotlin Coroutines を体系化し、レビューや実装時の判断基準を提供するためにドキュメントと Skill を追加しました。 
- 既存のアーキテクチャ方針（`doc/strategy-modularization.md`、`doc/strategy-dependency-injection.md`、`doc/architecture-layer-data.md`、`doc/CONVENTION_CODING.md`）と整合させ、レイヤ責務・Dispatcher/Scope 注入・キャンセル・例外処理を明確化するためです。
- KMP で共通化する shared ロジックを Android と iOS 双方で安全に扱えるよう、具体的な実装パターンとチェックリストを用意しました。

### Description
- 新規ファイル `doc/guideline-coroutines.md` を追加し、設計方針（なぜこの設計か）、レイヤ別ガイドライン、Scope 戦略、API/エラーハンドリング/キャンセル/テスト規約、代替案比較を整理しました。 
- Skill として `doc/skills/kotlin-coroutines-implementation-review/` を追加し、`SKILL.md` にトリガー条件・最小手順・判断原則・禁止事項を定義しました。 
- Skill の参照資料として `references/checklist.md`（レビュー用チェックリスト）と `references/patterns.md`（DataSource/ViewModel/Repository/テストの典型パターン）を追加し、実務ユースケースに基づく具体例を収録しました。 
- Skill 作成方針に従い `skill-creator` のガイドラインに沿って構成し、既存 `doc/` 方針との接続点（Dispatcher 注入、withContext、viewModelScope、appScope、runTest 等）を明確化しました。 

### Testing
- 追加ファイルの内容確認を自動化されたコマンドで検査し、`curl` による Issue 情報取得と `sed` / `nl` を用いたファイル中身の検証を行いました（正常に表示されることを確認）。
- リポジトリ状態の確認は自動コマンドで実行し、作成したファイル群がワークツリーに存在することを確認しました。 
- ドキュメント追加のみのためビルドやユニットテストは実行しておらず、コード変更は含まれていないためビルド影響はありません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f15c6925c8320a2aba509503593c5)