### PR TITLE
現在地取得を追加し、地図の初期位置を現在地優先に変更

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools">
 
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
   <application
     android:name=".MainApplication"
     android:allowBackup="true"

--- a/android/feature/hoge/build.gradle.kts
+++ b/android/feature/hoge/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   implementation(compose.ui)
   implementation(compose.components.resources)
   implementation(compose.components.uiToolingPreview)
+  implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.core.ktx)
   implementation(libs.androidx.lifecycle.viewmodelCompose)
   implementation(libs.androidx.lifecycle.runtimeCompose)

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
@@ -1,7 +1,15 @@
 package app.kaito_dogi.smopin.feature.hoge
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -9,8 +17,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.kaito_dogi.smopin.shared.domain.smokingArea.Latitude
 import app.kaito_dogi.smopin.shared.domain.smokingArea.Location
+import app.kaito_dogi.smopin.shared.domain.smokingArea.Longitude
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
@@ -24,10 +36,23 @@ fun HogeScreen(
   modifier: Modifier = Modifier,
   viewModel: HogeViewModel = metroViewModel(),
 ) {
+  val context = LocalContext.current
   val uiState: HogeUiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+  val permissionLauncher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.RequestMultiplePermissions(),
+  ) { resultMap ->
+    val isGranted = resultMap.values.any { it }
+    if (isGranted) {
+      context.getCurrentLocation()?.let(viewModel::onCurrentLocationUpdate)
+    }
+  }
 
   LaunchedEffect(key1 = Unit) {
     viewModel.onCreate()
+    if (context.isLocationPermissionGranted()) {
+      context.getCurrentLocation()?.let(viewModel::onCurrentLocationUpdate)
+    }
   }
 
   Scaffold(
@@ -36,32 +61,96 @@ fun HogeScreen(
     Column(
       modifier = Modifier.padding(paddingValues = innerPadding),
     ) {
+      Button(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = {
+          permissionLauncher.launch(
+            arrayOf(
+              Manifest.permission.ACCESS_COARSE_LOCATION,
+              Manifest.permission.ACCESS_FINE_LOCATION,
+            ),
+          )
+        },
+      ) {
+        Text(text = "現在地を取得")
+      }
+
+      uiState.currentLocation?.let { currentLocation ->
+        Text(text = "current latitude: ${currentLocation.latitude.value}")
+        Text(text = "current longitude: ${currentLocation.longitude.value}")
+      }
+
       uiState.smokingAreaList.forEach { smokingArea ->
         Text(text = smokingArea.name)
         Text(text = "latitude: ${smokingArea.location.latitude.value}")
         Text(text = "longitude: ${smokingArea.location.longitude.value}")
       }
 
-      val initialSmokingArea = uiState.smokingAreaList.getOrNull(index = 0)
-      if (initialSmokingArea != null) {
-        val initialPosition = remember(key1 = initialSmokingArea) { initialSmokingArea.location.toLatLng() }
-        val smokingAreaMakerState = rememberMarkerState(position = initialPosition)
+      val initialPosition = remember(uiState.currentLocation, uiState.smokingAreaList) {
+        uiState.currentLocation?.toLatLng()
+          ?: uiState.smokingAreaList.getOrNull(index = 0)?.location?.toLatLng()
+      }
+      if (initialPosition != null) {
         val cameraPositionState = rememberCameraPositionState {
-          position = CameraPosition.fromLatLngZoom(initialPosition, 20f)
+          position = CameraPosition.fromLatLngZoom(initialPosition, 17f)
         }
+        val smokingArea = uiState.smokingAreaList.getOrNull(index = 0)
+        val smokingAreaMakerState = rememberMarkerState(
+          position = smokingArea?.location?.toLatLng() ?: initialPosition,
+        )
+        val currentLocationMarkerState = rememberMarkerState(position = initialPosition)
+
+        LaunchedEffect(initialPosition) {
+          cameraPositionState.position = CameraPosition.fromLatLngZoom(initialPosition, 17f)
+        }
+
         GoogleMap(
           modifier = Modifier.weight(weight = 1f),
           cameraPositionState = cameraPositionState,
         ) {
-          Marker(
-            state = smokingAreaMakerState,
-            title = initialSmokingArea.name,
-            snippet = initialSmokingArea.name,
-          )
+          smokingArea?.let {
+            Marker(
+              state = smokingAreaMakerState,
+              title = it.name,
+              snippet = it.name,
+            )
+          }
+          uiState.currentLocation?.let {
+            Marker(
+              state = currentLocationMarkerState,
+              title = "現在地",
+              snippet = "現在地",
+            )
+          }
         }
       }
     }
   }
 }
 
-private fun Location.toLatLng() = LatLng(latitude.value, longitude.value)
+private fun Context.getCurrentLocation(): Location? {
+  val locationManager = getSystemService(Context.LOCATION_SERVICE) as? LocationManager ?: return null
+
+  return locationManager.getLastKnownLocation(LocationManager.FUSED_PROVIDER)
+    ?.toDomainModel()
+    ?: locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
+      ?.toDomainModel()
+    ?: locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)
+      ?.toDomainModel()
+}
+
+private fun Context.isLocationPermissionGranted(): Boolean {
+  val fineLocationPermission =
+    ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+  val coarseLocationPermission =
+    ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION)
+  return fineLocationPermission == PackageManager.PERMISSION_GRANTED
+    || coarseLocationPermission == PackageManager.PERMISSION_GRANTED
+}
+
+private fun Location.toLatLng(): LatLng = LatLng(latitude.value, longitude.value)
+
+private fun android.location.Location.toDomainModel(): Location = Location(
+  latitude = Latitude(value = latitude),
+  longitude = Longitude(value = longitude),
+)

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeUiState.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeUiState.kt
@@ -1,11 +1,16 @@
 package app.kaito_dogi.smopin.feature.hoge
 
+import app.kaito_dogi.smopin.shared.domain.smokingArea.Location
 import app.kaito_dogi.smopin.shared.domain.smokingArea.SmokingArea
 
 data class HogeUiState(
   val smokingAreaList: List<SmokingArea>,
+  val currentLocation: Location?,
 ) {
   companion object {
-    fun createInitial(): HogeUiState = HogeUiState(smokingAreaList = emptyList())
+    fun createInitial(): HogeUiState = HogeUiState(
+      smokingAreaList = emptyList(),
+      currentLocation = null,
+    )
   }
 }

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeViewModel.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeViewModel.kt
@@ -2,6 +2,7 @@ package app.kaito_dogi.smopin.feature.hoge
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.kaito_dogi.smopin.shared.domain.smokingArea.Location
 import app.kaito_dogi.smopin.shared.domain.smokingArea.SmokingAreaRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
@@ -29,13 +30,19 @@ class HogeViewModel(
         smokingAreaRepository.getSmokingAreaList()
       }.onSuccess { smokingAreaList ->
         _uiState.update {
-          HogeUiState(smokingAreaList = smokingAreaList)
+          it.copy(smokingAreaList = smokingAreaList)
         }
       }.onFailure {
         _uiState.update {
-          HogeUiState(smokingAreaList = emptyList())
+          it.copy(smokingAreaList = emptyList())
         }
       }
+    }
+  }
+
+  fun onCurrentLocationUpdate(location: Location) {
+    _uiState.update {
+      it.copy(currentLocation = location)
     }
   }
 }


### PR DESCRIPTION
close: #39 

### Motivation
- Issue #39 に対応して、Android 側でユーザーの現在地を取得して地図の初期中心を「現在地 > 最初の喫煙所」の優先順にするための実装を追加しました。 
- 実装方針は `docs/strategy-modularization.md` と `docs/strategy-dependency-injection.md` の方針に合わせ、OS 固有の権限/取得は Android アプリ層で扱い、位置情報の表現型は `shared:domain` の `Location` を使って将来的な KMP 共通化に備える設計としています。 
- ランタイム権限は UI 層（画面）で処理することで複雑性を抑えつつ、ドメイン型を共有することで再利用性と移植性を確保する判断を採用しました。 

### Description
- `AndroidManifest.xml` に `ACCESS_COARSE_LOCATION` と `ACCESS_FINE_LOCATION` を追加しました。 
- `HogeScreen.kt` にランタイムのパーミッション要求ボタンと権限結果ハンドリングを追加し、`Context.getCurrentLocation()` で最終既知位置を取得して `shared.domain.Location` に変換する処理を実装しました。 
- 地図の初期カメラ位置決定ロジックを `currentLocation` を優先するように変更し、現在地マーカー表示を追加しました。 
- 状態管理を拡張し、`HogeUiState` に `currentLocation` を追加し、`HogeViewModel` に `onCurrentLocationUpdate` を追加して状態更新を集約し、`androidx.activity.compose` 依存を `android:feature:hoge` に追加しました。 

### Testing
- 自動ビルド検証として `./gradlew :android:feature:hoge:compileDebugKotlin --stacktrace` を実行しましたが、実行環境の Java バージョン解釈エラー（`25.0.1` のパース例外）によりビルドは失敗し、コード由来ではない環境要因であることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d282fa77448320816dc73c3cd613a5)