### PR TITLE
feat(hoge): 位置追従・読み込みUI・喫煙所マーカー表示を実装

### DIFF
--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -36,8 +37,8 @@ import app.kaito_dogi.smopin.shared.domain.smokingArea.Longitude
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
-import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 import dev.zacsweers.metrox.viewmodel.metroViewModel
@@ -78,11 +79,29 @@ fun HogeScreen(
   val cameraPositionState = rememberCameraPositionState {
     position = CameraPosition.fromLatLngZoom(initialPosition, 17f)
   }
+  var lastCameraPosition by remember {
+    mutableStateOf(value = uiState.currentLocation)
+  }
+  var isMapLoaded by remember { mutableStateOf(value = false) }
 
   LaunchedEffect(uiState.currentLocation) {
     uiState.currentLocation?.let { currentLocation ->
-      val currentLatLng = currentLocation.toLatLng()
-      cameraPositionState.position = CameraPosition.fromLatLngZoom(currentLatLng, 17f)
+      val currentCameraPosition = CameraPosition.fromLatLngZoom(currentLocation.toLatLng(), MAP_ZOOM_LEVEL)
+      if (!isMapLoaded) {
+        cameraPositionState.position = currentCameraPosition
+        lastCameraPosition = currentLocation
+        return@let
+      }
+      if (lastCameraPosition == null) {
+        lastCameraPosition = currentLocation
+        cameraPositionState.position = currentCameraPosition
+        return@let
+      }
+      val distance = lastCameraPosition?.distanceTo(other = currentLocation) ?: 0.0
+      if (distance >= MIN_CAMERA_UPDATE_DISTANCE_METER) {
+        lastCameraPosition = currentLocation
+        cameraPositionState.position = currentCameraPosition
+      }
     }
   }
 
@@ -91,7 +110,7 @@ fun HogeScreen(
       modifier = Modifier
         .fillMaxSize()
         .padding(paddingValues = innerPadding),
-      verticalArrangement = Arrangement.spacedBy(space = dp(8)),
+      verticalArrangement = Arrangement.spacedBy(space = 8.dp),
     ) {
       if (!hasLocationPermission) {
         Button(
@@ -107,11 +126,6 @@ fun HogeScreen(
         ) {
           Text(text = "現在地を取得")
         }
-      }
-
-      uiState.currentLocation?.let { currentLocation ->
-        Text(text = "current latitude: ${currentLocation.latitude.value}")
-        Text(text = "current longitude: ${currentLocation.longitude.value}")
       }
 
       if (uiState.isLoading) {
@@ -130,13 +144,18 @@ fun HogeScreen(
             .weight(weight = 1f),
           cameraPositionState = cameraPositionState,
           properties = MapProperties(isMyLocationEnabled = hasLocationPermission),
+          onMapLoaded = {
+            isMapLoaded = true
+          },
         ) {
           uiState.smokingAreaList.forEach { smokingArea ->
-            Marker(
-              state = rememberMarkerState(position = smokingArea.location.toLatLng()),
-              title = smokingArea.name,
-              snippet = smokingArea.name,
-            )
+            key(smokingArea.name) {
+              Marker(
+                state = rememberMarkerState(position = smokingArea.location.toLatLng()),
+                title = smokingArea.name,
+                snippet = smokingArea.name,
+              )
+            }
           }
         }
       }
@@ -213,6 +232,14 @@ private fun Context.isFineLocationPermissionGranted(): Boolean =
 
 private fun Location.toLatLng(): LatLng = LatLng(latitude.value, longitude.value)
 
+private fun Location.distanceTo(other: Location): Double {
+  val latitudeDiff = latitude.value - other.latitude.value
+  val longitudeDiff = longitude.value - other.longitude.value
+  val latitudeMeter = latitudeDiff * LATITUDE_DEGREE_TO_METER
+  val longitudeMeter = longitudeDiff * LONGITUDE_DEGREE_TO_METER
+  return kotlin.math.sqrt(latitudeMeter * latitudeMeter + longitudeMeter * longitudeMeter)
+}
+
 private fun android.location.Location.toDomainModel(): Location = Location(
   latitude = Latitude(value = latitude),
   longitude = Longitude(value = longitude),
@@ -220,5 +247,9 @@ private fun android.location.Location.toDomainModel(): Location = Location(
 
 private const val NETWORK_UPDATE_INTERVAL_MILLIS: Long = 10_000L
 private const val NETWORK_UPDATE_DISTANCE_METER: Float = 20f
-private const val GPS_UPDATE_INTERVAL_MILLIS: Long = 5_000L
+private const val GPS_UPDATE_INTERVAL_MILLIS: Long = 5_00L
 private const val GPS_UPDATE_DISTANCE_METER: Float = 10f
+private const val MIN_CAMERA_UPDATE_DISTANCE_METER: Double = 15.0
+private const val LATITUDE_DEGREE_TO_METER: Double = 111_320.0
+private const val LONGITUDE_DEGREE_TO_METER: Double = 91_000.0
+private const val MAP_ZOOM_LEVEL: Float = 17f

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
@@ -37,7 +37,7 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
-import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 import dev.zacsweers.metrox.viewmodel.metroViewModel
@@ -78,14 +78,10 @@ fun HogeScreen(
   val cameraPositionState = rememberCameraPositionState {
     position = CameraPosition.fromLatLngZoom(initialPosition, 17f)
   }
-  val currentLocationMarkerState = remember {
-    MarkerState(position = initialPosition)
-  }
 
   LaunchedEffect(uiState.currentLocation) {
     uiState.currentLocation?.let { currentLocation ->
       val currentLatLng = currentLocation.toLatLng()
-      currentLocationMarkerState.position = currentLatLng
       cameraPositionState.position = CameraPosition.fromLatLngZoom(currentLatLng, 17f)
     }
   }
@@ -133,19 +129,13 @@ fun HogeScreen(
             .fillMaxWidth()
             .weight(weight = 1f),
           cameraPositionState = cameraPositionState,
+          properties = MapProperties(isMyLocationEnabled = hasLocationPermission),
         ) {
           uiState.smokingAreaList.forEach { smokingArea ->
             Marker(
               state = rememberMarkerState(position = smokingArea.location.toLatLng()),
               title = smokingArea.name,
               snippet = smokingArea.name,
-            )
-          }
-          uiState.currentLocation?.let {
-            Marker(
-              state = currentLocationMarkerState,
-              title = "現在地",
-              snippet = "現在地",
             )
           }
         }

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
@@ -3,21 +3,31 @@ package app.kaito_dogi.smopin.feature.hoge
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.location.LocationListener
 import android.location.LocationManager
+import android.os.Looper
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.kaito_dogi.smopin.shared.domain.smokingArea.Latitude
@@ -30,6 +40,9 @@ import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 import dev.zacsweers.metrox.viewmodel.metroViewModel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 @Composable
 fun HogeScreen(
@@ -38,41 +51,60 @@ fun HogeScreen(
 ) {
   val context = LocalContext.current
   val uiState: HogeUiState by viewModel.uiState.collectAsStateWithLifecycle()
+  var hasLocationPermission by remember { mutableStateOf(value = context.isLocationPermissionGranted()) }
 
   val permissionLauncher = rememberLauncherForActivityResult(
     contract = ActivityResultContracts.RequestMultiplePermissions(),
   ) { resultMap ->
-    val isGranted = resultMap.values.any { it }
-    if (isGranted) {
-      context.getCurrentLocation()?.let(viewModel::onCurrentLocationUpdate)
-    }
+    hasLocationPermission = resultMap.values.any { it }
   }
 
   LaunchedEffect(key1 = Unit) {
     viewModel.onCreate()
-    if (context.isLocationPermissionGranted()) {
-      context.getCurrentLocation()?.let(viewModel::onCurrentLocationUpdate)
+  }
+
+  LaunchedEffect(hasLocationPermission) {
+    if (hasLocationPermission) {
+      context.locationUpdateFlow().collect(viewModel::onCurrentLocationUpdate)
     }
   }
 
-  Scaffold(
-    modifier = modifier,
-  ) { innerPadding ->
+  val initialPosition = remember(uiState.currentLocation, uiState.smokingAreaList) {
+    uiState.currentLocation?.toLatLng()
+      ?: uiState.smokingAreaList.getOrNull(index = 0)?.location?.toLatLng()
+      ?: LatLng(35.681236, 139.767125)
+  }
+  val cameraPositionState = rememberCameraPositionState {
+    position = CameraPosition.fromLatLngZoom(initialPosition, 17f)
+  }
+
+  LaunchedEffect(uiState.currentLocation) {
+    uiState.currentLocation?.let { currentLocation ->
+      cameraPositionState.position = CameraPosition.fromLatLngZoom(currentLocation.toLatLng(), 17f)
+    }
+  }
+
+  Scaffold(modifier = modifier) { innerPadding ->
     Column(
-      modifier = Modifier.padding(paddingValues = innerPadding),
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(paddingValues = innerPadding),
+      verticalArrangement = Arrangement.spacedBy(space = dp(8)),
     ) {
-      Button(
-        modifier = Modifier.fillMaxWidth(),
-        onClick = {
-          permissionLauncher.launch(
-            arrayOf(
-              Manifest.permission.ACCESS_COARSE_LOCATION,
-              Manifest.permission.ACCESS_FINE_LOCATION,
-            ),
-          )
-        },
-      ) {
-        Text(text = "現在地を取得")
+      if (!hasLocationPermission) {
+        Button(
+          modifier = Modifier.fillMaxWidth(),
+          onClick = {
+            permissionLauncher.launch(
+              arrayOf(
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+              ),
+            )
+          },
+        ) {
+          Text(text = "現在地を取得")
+        }
       }
 
       uiState.currentLocation?.let { currentLocation ->
@@ -80,44 +112,32 @@ fun HogeScreen(
         Text(text = "current longitude: ${currentLocation.longitude.value}")
       }
 
-      uiState.smokingAreaList.forEach { smokingArea ->
-        Text(text = smokingArea.name)
-        Text(text = "latitude: ${smokingArea.location.latitude.value}")
-        Text(text = "longitude: ${smokingArea.location.longitude.value}")
-      }
-
-      val initialPosition = remember(uiState.currentLocation, uiState.smokingAreaList) {
-        uiState.currentLocation?.toLatLng()
-          ?: uiState.smokingAreaList.getOrNull(index = 0)?.location?.toLatLng()
-      }
-      if (initialPosition != null) {
-        val cameraPositionState = rememberCameraPositionState {
-          position = CameraPosition.fromLatLngZoom(initialPosition, 17f)
+      if (uiState.isLoading) {
+        Box(
+          modifier = Modifier
+            .fillMaxWidth()
+            .weight(weight = 1f),
+          contentAlignment = Alignment.Center,
+        ) {
+          CircularProgressIndicator()
         }
-        val smokingArea = uiState.smokingAreaList.getOrNull(index = 0)
-        val smokingAreaMakerState = rememberMarkerState(
-          position = smokingArea?.location?.toLatLng() ?: initialPosition,
-        )
-        val currentLocationMarkerState = rememberMarkerState(position = initialPosition)
-
-        LaunchedEffect(initialPosition) {
-          cameraPositionState.position = CameraPosition.fromLatLngZoom(initialPosition, 17f)
-        }
-
+      } else {
         GoogleMap(
-          modifier = Modifier.weight(weight = 1f),
+          modifier = Modifier
+            .fillMaxWidth()
+            .weight(weight = 1f),
           cameraPositionState = cameraPositionState,
         ) {
-          smokingArea?.let {
+          uiState.smokingAreaList.forEach { smokingArea ->
             Marker(
-              state = smokingAreaMakerState,
-              title = it.name,
-              snippet = it.name,
+              state = rememberMarkerState(position = smokingArea.location.toLatLng()),
+              title = smokingArea.name,
+              snippet = smokingArea.name,
             )
           }
-          uiState.currentLocation?.let {
+          uiState.currentLocation?.let { currentLocation ->
             Marker(
-              state = currentLocationMarkerState,
+              state = rememberMarkerState(position = currentLocation.toLatLng()),
               title = "現在地",
               snippet = "現在地",
             )
@@ -128,16 +148,59 @@ fun HogeScreen(
   }
 }
 
-private fun Context.getCurrentLocation(): Location? {
-  val locationManager = getSystemService(Context.LOCATION_SERVICE) as? LocationManager ?: return null
+private fun Context.locationUpdateFlow(): Flow<Location> = callbackFlow {
+  val locationManager = getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+  if (locationManager == null) {
+    close()
+    return@callbackFlow
+  }
 
-  return locationManager.getLastKnownLocation(LocationManager.FUSED_PROVIDER)
+  val listener = LocationListener { location ->
+    trySend(location.toDomainModel())
+  }
+
+  getLastKnownLocation(locationManager = locationManager)?.let { location ->
+    trySend(location)
+  }
+
+  if (
+    isLocationPermissionGranted() &&
+    locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)
+  ) {
+    locationManager.requestLocationUpdates(
+      LocationManager.NETWORK_PROVIDER,
+      NETWORK_UPDATE_INTERVAL_MILLIS,
+      NETWORK_UPDATE_DISTANCE_METER,
+      listener,
+      Looper.getMainLooper(),
+    )
+  }
+
+  if (
+    isFineLocationPermissionGranted() &&
+    locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
+  ) {
+    locationManager.requestLocationUpdates(
+      LocationManager.GPS_PROVIDER,
+      GPS_UPDATE_INTERVAL_MILLIS,
+      GPS_UPDATE_DISTANCE_METER,
+      listener,
+      Looper.getMainLooper(),
+    )
+  }
+
+  awaitClose {
+    locationManager.removeUpdates(listener)
+  }
+}
+
+private fun Context.getLastKnownLocation(locationManager: LocationManager): Location? =
+  locationManager.getLastKnownLocation(LocationManager.FUSED_PROVIDER)
     ?.toDomainModel()
     ?: locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
       ?.toDomainModel()
     ?: locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)
       ?.toDomainModel()
-}
 
 private fun Context.isLocationPermissionGranted(): Boolean {
   val fineLocationPermission =
@@ -148,9 +211,18 @@ private fun Context.isLocationPermissionGranted(): Boolean {
     || coarseLocationPermission == PackageManager.PERMISSION_GRANTED
 }
 
+private fun Context.isFineLocationPermissionGranted(): Boolean =
+  ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) ==
+    PackageManager.PERMISSION_GRANTED
+
 private fun Location.toLatLng(): LatLng = LatLng(latitude.value, longitude.value)
 
 private fun android.location.Location.toDomainModel(): Location = Location(
   latitude = Latitude(value = latitude),
   longitude = Longitude(value = longitude),
 )
+
+private const val NETWORK_UPDATE_INTERVAL_MILLIS: Long = 10_000L
+private const val NETWORK_UPDATE_DISTANCE_METER: Float = 20f
+private const val GPS_UPDATE_INTERVAL_MILLIS: Long = 5_000L
+private const val GPS_UPDATE_DISTANCE_METER: Float = 10f

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
@@ -37,6 +37,7 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 import dev.zacsweers.metrox.viewmodel.metroViewModel
@@ -77,10 +78,15 @@ fun HogeScreen(
   val cameraPositionState = rememberCameraPositionState {
     position = CameraPosition.fromLatLngZoom(initialPosition, 17f)
   }
+  val currentLocationMarkerState = remember {
+    MarkerState(position = initialPosition)
+  }
 
   LaunchedEffect(uiState.currentLocation) {
     uiState.currentLocation?.let { currentLocation ->
-      cameraPositionState.position = CameraPosition.fromLatLngZoom(currentLocation.toLatLng(), 17f)
+      val currentLatLng = currentLocation.toLatLng()
+      currentLocationMarkerState.position = currentLatLng
+      cameraPositionState.position = CameraPosition.fromLatLngZoom(currentLatLng, 17f)
     }
   }
 
@@ -135,9 +141,9 @@ fun HogeScreen(
               snippet = smokingArea.name,
             )
           }
-          uiState.currentLocation?.let { currentLocation ->
+          uiState.currentLocation?.let {
             Marker(
-              state = rememberMarkerState(position = currentLocation.toLatLng()),
+              state = currentLocationMarkerState,
               title = "現在地",
               snippet = "現在地",
             )

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeUiState.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeUiState.kt
@@ -4,11 +4,13 @@ import app.kaito_dogi.smopin.shared.domain.smokingArea.Location
 import app.kaito_dogi.smopin.shared.domain.smokingArea.SmokingArea
 
 data class HogeUiState(
+  val isLoading: Boolean,
   val smokingAreaList: List<SmokingArea>,
   val currentLocation: Location?,
 ) {
   companion object {
     fun createInitial(): HogeUiState = HogeUiState(
+      isLoading = true,
       smokingAreaList = emptyList(),
       currentLocation = null,
     )

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeViewModel.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeViewModel.kt
@@ -26,15 +26,24 @@ class HogeViewModel(
 
   fun onCreate() {
     viewModelScope.launch {
+      _uiState.update {
+        it.copy(isLoading = true)
+      }
       runCatching {
         smokingAreaRepository.getSmokingAreaList()
       }.onSuccess { smokingAreaList ->
         _uiState.update {
-          it.copy(smokingAreaList = smokingAreaList)
+          it.copy(
+            isLoading = false,
+            smokingAreaList = smokingAreaList,
+          )
         }
       }.onFailure {
         _uiState.update {
-          it.copy(smokingAreaList = emptyList())
+          it.copy(
+            isLoading = false,
+            smokingAreaList = emptyList(),
+          )
         }
       }
     }


### PR DESCRIPTION
### Motivation
- Issue #40 と #41 に従い、喫煙所一覧取得時の読み込み表示とユーザー位置の継続追従を実装するための変更です。 
- プロジェクト方針（`docs/strategy-modularization.md`、`docs/architecture-layer-data.md`、`docs/strategy-dependency-injection.md`、`docs/convention-coding.md`）に従い機能は `:feature:hoge` に閉じ、ViewModel 側で UI 状態を管理する設計を維持しました。 
- UI 側での明示的な `loading` 状態と継続的な位置更新を導入することで再利用性・差し替え性を維持しつつ画面要件を満たします。 

### Description
- `HogeUiState` に `isLoading` を追加し、初期状態を `true` に設定しました。 
- `HogeViewModel` を変更して `smokingAreaRepository.getSmokingAreaList()` の呼び出し前後で `isLoading` を切り替えるようにし、成功/失敗どちらでもロード終了するようにしました。 
- `HogeScreen` を大幅に更新し、権限取得フロー、`callbackFlow` ベースの `locationUpdateFlow()` を追加して `LocationManager` の `NETWORK_PROVIDER` と `GPS_PROVIDER` を使い分けた継続的な位置取得を実装しました。 
- 地図表示を更新して取得した喫煙所一覧の全マーカーと現在地マーカーを描画し、初回読み込み中は `CircularProgressIndicator` を表示し読み込み完了後に地図へ切り替える仕様にしました。 
- カメラ位置は現在地更新に追従するように整理し、UI の細かなレイアウト（`fillMaxSize`, `Arrangement.spacedBy` 等）と更新間隔定数を導入しました。 
- 既存のドメイン契約は保持し `SmokingAreaRepository.getSmokingAreaList()` をそのまま利用することでレイヤ分離（再利用性・テスト差し替え性）を維持しました。 

### Testing
- `./gradlew :android:feature:hoge:compileDebugKotlin` を実行しましたが、この環境の Android SDK/ツールチェーンに起因するエラー (`25.0.1`) によりビルドは失敗しました。 
- `./gradlew :shared:data:allTests` を実行しましたが同様に環境依存のため実行できず失敗しました。 
- 自動化テストはこの環境では実行できなかったため、CI 上での `./gradlew assembleDebug` とユニットテスト実行を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d31480829083209e828c2922328486)