### PR TITLE
Android: HogeScreen を地図全画面表示にして insets と経路案内カードを追加 (issues #41-#43)

### DIFF
--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
@@ -13,8 +13,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.Button
@@ -32,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -88,6 +90,14 @@ fun HogeScreen(
     mutableStateOf(value = uiState.currentLocation)
   }
   var isMapLoaded by remember { mutableStateOf(value = false) }
+  val layoutDirection = LocalLayoutDirection.current
+  val safeDrawingPaddingValues = WindowInsets.safeDrawing.asPaddingValues()
+  val mapContentPadding = PaddingValues(
+    start = safeDrawingPaddingValues.calculateLeftPadding(layoutDirection),
+    end = safeDrawingPaddingValues.calculateRightPadding(layoutDirection),
+    top = safeDrawingPaddingValues.calculateTopPadding(),
+    bottom = safeDrawingPaddingValues.calculateBottomPadding() + MAP_ROUTE_GUIDE_HEIGHT,
+  )
 
   LaunchedEffect(uiState.currentLocation) {
     uiState.currentLocation?.let { currentLocation ->
@@ -120,6 +130,7 @@ fun HogeScreen(
         cameraPositionState = cameraPositionState,
         properties = MapProperties(isMyLocationEnabled = hasLocationPermission),
         uiSettings = MapUiSettings(mapToolbarEnabled = true),
+        contentPadding = mapContentPadding,
         onMapLoaded = {
           isMapLoaded = true
         },
@@ -165,8 +176,7 @@ fun HogeScreen(
         Card(
           modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-            .navigationBarsPadding(),
+            .padding(horizontal = 16.dp, vertical = 12.dp),
         ) {
           Text(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
@@ -277,3 +287,4 @@ private const val MIN_CAMERA_UPDATE_DISTANCE_METER: Double = 15.0
 private const val LATITUDE_DEGREE_TO_METER: Double = 111_320.0
 private const val LONGITUDE_DEGREE_TO_METER: Double = 91_000.0
 private const val MAP_ZOOM_LEVEL: Float = 17f
+private val MAP_ROUTE_GUIDE_HEIGHT = 72.dp

--- a/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
+++ b/android/feature/hoge/src/main/kotlin/app/kaito_dogi/smopin/feature/hoge/HogeScreen.kt
@@ -13,8 +13,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -38,6 +42,7 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
@@ -105,58 +110,77 @@ fun HogeScreen(
     }
   }
 
-  Scaffold(modifier = modifier) { innerPadding ->
-    Column(
-      modifier = Modifier
-        .fillMaxSize()
-        .padding(paddingValues = innerPadding),
-      verticalArrangement = Arrangement.spacedBy(space = 8.dp),
-    ) {
-      if (!hasLocationPermission) {
-        Button(
-          modifier = Modifier.fillMaxWidth(),
-          onClick = {
-            permissionLauncher.launch(
-              arrayOf(
-                Manifest.permission.ACCESS_COARSE_LOCATION,
-                Manifest.permission.ACCESS_FINE_LOCATION,
-              ),
+  Scaffold(
+    modifier = modifier,
+    contentWindowInsets = WindowInsets(left = 0, top = 0, right = 0, bottom = 0),
+  ) {
+    Box(modifier = Modifier.fillMaxSize()) {
+      GoogleMap(
+        modifier = Modifier.fillMaxSize(),
+        cameraPositionState = cameraPositionState,
+        properties = MapProperties(isMyLocationEnabled = hasLocationPermission),
+        uiSettings = MapUiSettings(mapToolbarEnabled = true),
+        onMapLoaded = {
+          isMapLoaded = true
+        },
+      ) {
+        uiState.smokingAreaList.forEach { smokingArea ->
+          key(smokingArea.name) {
+            Marker(
+              state = rememberMarkerState(position = smokingArea.location.toLatLng()),
+              title = smokingArea.name,
+              snippet = smokingArea.name,
             )
-          },
+          }
+        }
+      }
+
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .windowInsetsPadding(WindowInsets.safeDrawing),
+        verticalArrangement = Arrangement.SpaceBetween,
+      ) {
+        Column(
+          modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+          verticalArrangement = Arrangement.spacedBy(space = 8.dp),
         ) {
-          Text(text = "現在地を取得")
+          if (!hasLocationPermission) {
+            Button(
+              modifier = Modifier.fillMaxWidth(),
+              onClick = {
+                permissionLauncher.launch(
+                  arrayOf(
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                  ),
+                )
+              },
+            ) {
+              Text(text = "現在地を取得")
+            }
+          }
+        }
+
+        Card(
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .navigationBarsPadding(),
+        ) {
+          Text(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            text = "ピンをタップしてから、右下の経路ボタンでルートを表示できます",
+          )
         }
       }
 
       if (uiState.isLoading) {
         Box(
-          modifier = Modifier
-            .fillMaxWidth()
-            .weight(weight = 1f),
+          modifier = Modifier.fillMaxSize(),
           contentAlignment = Alignment.Center,
         ) {
           CircularProgressIndicator()
-        }
-      } else {
-        GoogleMap(
-          modifier = Modifier
-            .fillMaxWidth()
-            .weight(weight = 1f),
-          cameraPositionState = cameraPositionState,
-          properties = MapProperties(isMyLocationEnabled = hasLocationPermission),
-          onMapLoaded = {
-            isMapLoaded = true
-          },
-        ) {
-          uiState.smokingAreaList.forEach { smokingArea ->
-            key(smokingArea.name) {
-              Marker(
-                state = rememberMarkerState(position = smokingArea.location.toLatLng()),
-                title = smokingArea.name,
-                snippet = smokingArea.name,
-              )
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
close: #41 #42 #43

### Motivation
- Issues #41〜#43 の要件に従い、喫煙所探索の主体である地図体験を損なわずに「読み込み表示」「経路案内の導線」「edge-to-edge 表示」を満たすために UI を見直しました。
- プロジェクトのモジュール方針（`docs/strategy-modularization.md`）に合わせて、影響範囲は `:android:feature:hoge` に限定し、共通モジュールへの責務拡散を避けています。 

### Description
- `android/feature/hoge/src/main/kotlin/.../HogeScreen.kt` を更新して、GoogleMap を常時フルスクリーンで表示するレイアウトへ変更し、地図を土台に Permission ボタン／案内カード／ローディングをオーバーレイ表示にしました。 
- Map の UI 設定で `MapUiSettings(mapToolbarEnabled = true)` を有効化して Android のマップツールバー（右下の経路ボタン）を明示的に利用可能にしました。 
- `Scaffold` のデフォルト Insets を無効化して地図自体は `fillMaxSize()` にし、オーバーレイ要素には `WindowInsets.safeDrawing` と `navigationBarsPadding()` を適用して edge-to-edge レイアウトを実現しました。 
- 読み込み中は地図の上に中央寄せの `CircularProgressIndicator` を重ね、ピン誘導のために画面下部に案内 `Card`（「ピンをタップしてから、右下の経路ボタンでルートを表示できます」）を追加しました。 

### Testing
- ビルド検証として `./gradlew :android:feature:hoge:compileDebugKotlin --stacktrace` を実行しましたが、ローカル環境の Java/Gradle 設定起因のパーサーエラー（`IllegalArgumentException: 25.0.1`）でコンパイル段階に到達できずビルドは失敗しました。 
- 単体テストや UI テストはこの変更で追加しておらず、自動テストは上記ビルド試行のみです。 
- 実行環境の Java/Gradle バージョンを合わせた上で再ビルドを推奨します（ローカルまたは CI 上での確認をお願いします）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d382d8b744832081415bdaeee46550)