### PR TITLE
位置取得を `callbackFlow` に変更し Flow API を `*Stream` に統一、ドキュメント更新

### DIFF
--- a/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModel.kt
+++ b/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModel.kt
@@ -28,7 +28,7 @@ class MapViewModel(
   private val viewModelState: MutableStateFlow<MapViewModelState> = MutableStateFlow(value = MapViewModelState.createInitial())
 
   // TODO: isPreciseEnabled を正確な位置情報のパーミッションが付与されているかどうかで切り替える
-  private val currentLocation: Flow<Location> = locationRepository.getCurrentLocation(isPreciseEnabled = false)
+  private val currentLocation: Flow<Location> = locationRepository.getCurrentLocationStream(isPreciseEnabled = false)
 
   val uiState: StateFlow<MapUiState> = viewModelState.combine(
     flow = currentLocation,

--- a/doc/architecture-layer-data.md
+++ b/doc/architecture-layer-data.md
@@ -65,7 +65,7 @@ data class UserDataModel(
 interface UserRepository {
   suspend fun getUserList(): List<User>
   suspend fun createUser(user: User)
-  fun getUser(userId: UserId): Flow<User>
+  fun getUserStream(userId: UserId): Flow<User>
   suspend fun updateUser(user: User)
   suspend fun deleteUser(userId: UserId)
 }
@@ -74,6 +74,7 @@ interface UserRepository {
 - CRUD 処理は `create`, `get`, `update`, `delete` と命名する
 - ワンショットな読み取り処理は `suspend fun` で定義する
 - オブザーバルな読み取り処理は `suspend fun` を使用せず、返り値に `Flow` を使用する
+- 返り値が `Flow` の場合、メソッド名に接尾辞 `Stream` をつける
 - 返り値が `List`, `Map`, `Set` の場合、メソッド名に接尾辞 `List`, `Map`, `Set` をつける
 
 #### 実装例
@@ -87,7 +88,7 @@ internal class DefaultUserRepository(
   override suspend fun getUserList(): List<User> = userNetworkDataSource.getUserList()
     .map(transform = UserMapper::toDomainModel)
 
-  override fun getUser(userId: UserId): Flow<User> = userDiskDataSource.getUser(userId = userId)
+  override fun getUserStream(userId: UserId): Flow<User> = userDiskDataSource.getUserStream(userId = userId)
     .map(transform = UserMapper::toDomainModel)
 
   // override suspend fun createUser(user: User)
@@ -125,12 +126,14 @@ internal class DefaultUserRepository(
 ```kt
 interface UserNetworkDataSource {
   suspend fun getUserList(): List<UserDataModel>
+  fun getUserStream(userId: UserId): Flow<UserDataModel>
 }
 ```
 
 - CRUD 処理は `create`, `get`, `update`, `delete` と命名する
 - ワンショットな読み取り処理は `suspend fun` で定義する
 - オブザーバルな読み取り処理は `suspend fun` を使用せず、返り値に `Flow` を使用する
+- 返り値が `Flow` の場合、メソッド名に接尾辞 `Stream` をつける
 - 返り値が List の場合、メソッド名に接尾辞 `List` をつける
 
 #### 実装例

--- a/doc/convention-coding.md
+++ b/doc/convention-coding.md
@@ -13,6 +13,12 @@
 - OK：`getSmokingAreaList`
 - NG：`getSmokingAreas`
 
+### 返り値が `Flow` の場合、メソッド名に接尾辞 `Stream` をつける
+
+- 理由：オブザーバルな読み取りであることを命名から判断できるようにするため
+- OK：`getCurrentLocationStream`
+- NG：`getCurrentLocation`
+
 ## 文法
 
 ### メソッドの返り値を式で表現できる場合は `=` を使用する（Expression body）

--- a/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/DefaultLocationRepository.kt
+++ b/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/DefaultLocationRepository.kt
@@ -10,6 +10,6 @@ import kotlinx.coroutines.flow.map
 internal class DefaultLocationRepository(
   private val locationDataSource: LocationDataSource,
 ) : LocationRepository {
-  override fun getCurrentLocation(isPreciseEnabled: Boolean): Flow<Location> = locationDataSource.getCurrentLocation(isPreciseEnabled = isPreciseEnabled)
+  override fun getCurrentLocationStream(isPreciseEnabled: Boolean): Flow<Location> = locationDataSource.getCurrentLocationStream(isPreciseEnabled = isPreciseEnabled)
     .map(transform = LocationMapper::toDomainModel)
 }

--- a/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationDataSource.kt
+++ b/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationDataSource.kt
@@ -6,7 +6,7 @@ import kotlin.time.Duration.Companion.seconds
 
 // TODO: interface にデフォルト引数を渡せるかどうか確認する
 interface LocationDataSource {
-  fun getCurrentLocation(
+  fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration = 5.seconds,
   ): Flow<LocationDataModel>

--- a/shared/domain/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/domain/smokingArea/location/LocationRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/domain/smokingArea/location/LocationRepository.kt
@@ -3,5 +3,5 @@ package app.kaito_dogi.smopin.shared.domain.smokingArea.location
 import kotlinx.coroutines.flow.Flow
 
 interface LocationRepository {
-  fun getCurrentLocation(isPreciseEnabled: Boolean): Flow<Location>
+  fun getCurrentLocationStream(isPreciseEnabled: Boolean): Flow<Location>
 }

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -2,15 +2,43 @@ package app.kaito_dogi.smopin.shared.location
 
 import app.kaito_dogi.smopin.shared.data.location.LocationDataModel
 import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.Priority
-import com.google.android.gms.tasks.CancellationTokenSource
-import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 internal actual class PlatformLocationClient(
   private val fusedLocationClient: FusedLocationProviderClient,
 ) {
-  actual suspend fun getLocation(isPreciseEnabled: Boolean): LocationDataModel = fusedLocationClient.getCurrentLocation(
-    if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY,
-    CancellationTokenSource().token,
-  ).await().let(block = LocationMapper::toDataModel)
+  actual fun getLocationStream(
+    isPreciseEnabled: Boolean,
+    intervalDuration: Duration,
+  ): Flow<LocationDataModel> = callbackFlow {
+    val locationCallback = object : LocationCallback() {
+      override fun onLocationResult(locationResult: LocationResult) {
+        val location = locationResult.lastLocation ?: return
+        trySend(
+          element = LocationMapper.toDataModel(location = location),
+        )
+      }
+    }
+    val priority = if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY
+    val request = LocationRequest.Builder(
+      priority,
+      intervalDuration.toLong(unit = DurationUnit.MILLISECONDS),
+    ).build()
+    fusedLocationClient.requestLocationUpdates(
+      request,
+      locationCallback,
+      null,
+    )
+    awaitClose {
+      fusedLocationClient.removeLocationUpdates(locationCallback)
+    }
+  }
 }

--- a/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/DefaultLocationDataSource.kt
+++ b/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/DefaultLocationDataSource.kt
@@ -6,12 +6,8 @@ import app.kaito_dogi.smopin.shared.data.location.LocationDataModel
 import app.kaito_dogi.smopin.shared.data.location.LocationDataSource
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.isActive
 import kotlin.time.Duration
 
 @Inject
@@ -19,15 +15,13 @@ internal class DefaultLocationDataSource(
   private val platformLocationClient: PlatformLocationClient,
   @param:AppDispatcher(dispatcher = AppDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : LocationDataSource {
-  override fun getCurrentLocation(
+  override fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
-  ): Flow<LocationDataModel> = flow {
-    while (currentCoroutineContext().isActive) {
-      emit(value = platformLocationClient.getLocation(isPreciseEnabled = isPreciseEnabled))
-      delay(duration = intervalDuration)
-    }
-  }.flowOn(
+  ): Flow<LocationDataModel> = platformLocationClient.getLocationStream(
+    isPreciseEnabled = isPreciseEnabled,
+    intervalDuration = intervalDuration,
+  ).flowOn(
     context = ioDispatcher,
   )
 }

--- a/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.kt
+++ b/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.kt
@@ -1,7 +1,12 @@
 package app.kaito_dogi.smopin.shared.location
 
 import app.kaito_dogi.smopin.shared.data.location.LocationDataModel
+import kotlinx.coroutines.flow.Flow
+import kotlin.time.Duration
 
 internal expect class PlatformLocationClient {
-  suspend fun getLocation(isPreciseEnabled: Boolean): LocationDataModel
+  fun getLocationStream(
+    isPreciseEnabled: Boolean,
+    intervalDuration: Duration,
+  ): Flow<LocationDataModel>
 }


### PR DESCRIPTION
### Motivation
- 位置情報取得をイベント駆動（コールバック）に合わせて安定化させるため、ポーリング実装を `callbackFlow` ベースに置き換えること。
- 継続購読を返す `Flow` 系 API は命名で明示する方針に合わせて、返り値が `Flow` のメソッドに `Stream` 接尾辞を付与し一貫性を保つこと。
- 実装変更に合わせて `doc/` のコーディング・アーキテクチャ規約を更新し、開発者間の規約ズレを解消すること。

### Description
- Android 実装をコールバック駆動に変更：`shared/location/.../PlatformLocationClient.android.kt` の位置取得を `suspend getLocation(...)` → `fun getLocationStream(...): Flow<LocationDataModel>` に変更し、`callbackFlow` と `awaitClose` を使って `requestLocationUpdates`/`removeLocationUpdates` を扱う実装に置換。
- 上流 API を `*Stream` 命名へ変更：`PlatformLocationClient` の `getLocationStream`、`shared/location` の `DefaultLocationDataSource.getCurrentLocationStream`、`shared/data` の `LocationDataSource.getCurrentLocationStream`、`shared/domain` の `LocationRepository.getCurrentLocationStream`、および `shared/data` の `DefaultLocationRepository` を順に更新。
- ViewModel 側での呼び出しも更新：`android/feature/map/MapViewModel` で `locationRepository.getCurrentLocationStream(...)` を購読するよう修正。
- ドキュメント更新：`doc/convention-coding.md` と `doc/architecture-layer-data.md` に「返り値が `Flow` の場合はメソッド名に `Stream` 接尾辞を付ける」旨を追記し、サンプルも `*Stream` に合わせて修正。

### Testing
- 変更後に影響するモジュールのビルドを `./gradlew :shared:location:compileDebugKotlinAndroid :shared:data:compileKotlinMetadata :android:feature:map:compileDebugKotlin --stacktrace` で試行しましたが、環境の JDK 解析エラー（`java.lang.IllegalArgumentException: 25.0.1`）によりビルドは失敗しました。
- ソース差分はローカルでコミット済みで、静的なコード差分レベルでは整合していますが、実行環境（JDK）を整えた上で再ビルド／ユニットテスト実行を推奨します。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7241e4b988320bbba704bc9b7ad32)