### PR TITLE
位置情報パーミッションの要求フローと要求済みフラグを実装

### DIFF
--- a/android/app/src/main/kotlin/app/kaito_dogi/smopin/di/AndroidAppGraph.kt
+++ b/android/app/src/main/kotlin/app/kaito_dogi/smopin/di/AndroidAppGraph.kt
@@ -5,6 +5,7 @@ import app.kaito_dogi.smopin.shared.common.AppDispatcherBindingContainer
 import app.kaito_dogi.smopin.shared.data.DataBindingContainer
 import app.kaito_dogi.smopin.shared.database.firestore.DatabaseFirestoreBindingContainer
 import app.kaito_dogi.smopin.shared.location.LocationBindingContainer
+import app.kaito_dogi.smopin.shared.location.LocationPreferencesBindingContainer
 import app.kaito_dogi.smopin.shared.location.PlatformLocationClientBindingContainer
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
@@ -20,6 +21,7 @@ import dev.zacsweers.metrox.viewmodel.ViewModelGraph
     DataBindingContainer::class,
     DatabaseFirestoreBindingContainer::class,
     LocationBindingContainer::class,
+    LocationPreferencesBindingContainer::class,
     PlatformLocationClientBindingContainer::class,
   ],
 )

--- a/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapScreen.kt
+++ b/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapScreen.kt
@@ -1,12 +1,18 @@
 package app.kaito_dogi.smopin.feature.map
 
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.kaito_dogi.smopin.feature.map.ext.toLatLng
 import com.google.android.gms.maps.model.CameraPosition
@@ -28,14 +34,60 @@ internal fun MapScreen(
   modifier: Modifier = Modifier,
   viewModel: MapViewModel = metroViewModel(),
 ) {
+  val context = LocalContext.current
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   val cameraPositionState = rememberCameraPositionState()
+  val locationPermissionLauncher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.RequestMultiplePermissions(),
+  ) { grantResultMap ->
+    val isPreciseGranted: Boolean = grantResultMap[Manifest.permission.ACCESS_FINE_LOCATION] == true
+    val isCoarseGranted: Boolean = grantResultMap[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+    viewModel.onPermissionResult(
+      isGranted = isPreciseGranted || isCoarseGranted,
+      isPrecise = isPreciseGranted,
+    )
+  }
 
   LaunchedEffect(key1 = Unit) {
     viewModel.onCreate()
   }
 
-  // FIXME: 現在位置を初めて取得したときにカメラのポジションを設定するように修正する
+  LaunchedEffect(key1 = uiState.uiState, key2 = uiState.shouldRequestPermission) {
+    if (uiState.uiState !is MapUiState.UiState.PermissionRequested) return@LaunchedEffect
+
+    val isPreciseGranted: Boolean = ContextCompat.checkSelfPermission(
+      context,
+      Manifest.permission.ACCESS_FINE_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED
+    val isCoarseGranted: Boolean = ContextCompat.checkSelfPermission(
+      context,
+      Manifest.permission.ACCESS_COARSE_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED
+
+    if (isPreciseGranted || isCoarseGranted) {
+      viewModel.onPermissionResult(
+        isGranted = true,
+        isPrecise = isPreciseGranted,
+      )
+      return@LaunchedEffect
+    }
+
+    if (uiState.shouldRequestPermission) {
+      viewModel.onPermissionRequested()
+      locationPermissionLauncher.launch(
+        arrayOf(
+          Manifest.permission.ACCESS_FINE_LOCATION,
+          Manifest.permission.ACCESS_COARSE_LOCATION,
+        ),
+      )
+    } else {
+      viewModel.onPermissionResult(
+        isGranted = false,
+        isPrecise = false,
+      )
+    }
+  }
+
   uiState.currentLocation?.let { currentLocation ->
     LaunchedEffect(key1 = currentLocation) {
       cameraPositionState.position = CameraPosition.fromLatLngZoom(currentLocation.toLatLng(), 17f)
@@ -59,15 +111,15 @@ private fun MapScreen(
 ) = Scaffold(
   modifier = modifier,
 ) { innerPadding ->
-  // TODO: 位置情報の許可状況に応じて MapProperties の isMyLocationEnabled を切り替える
+  if (!uiState.uiState.isMapShown) return@Scaffold
+
   GoogleMap(
     cameraPositionState = cameraPositionState,
-    properties = MapProperties(isMyLocationEnabled = true),
+    properties = MapProperties(isMyLocationEnabled = uiState.uiState is MapUiState.UiState.PermissionGranted),
     onMapLoaded = onMapLoaded,
     contentPadding = innerPadding,
   ) {
     uiState.smokingAreaList.forEach { smokingArea ->
-      // TODO: key の指定を考える
       Marker(
         state = rememberMarkerState(
           key = smokingArea.name,

--- a/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapUiState.kt
+++ b/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapUiState.kt
@@ -4,17 +4,42 @@ import app.kaito_dogi.smopin.shared.domain.smokingArea.location.Location
 import app.kaito_dogi.smopin.shared.domain.smokingArea.smokingArea.SmokingArea
 import kotlinx.serialization.Serializable
 
-// TODO: パーミッションを取得しているかどうかの表現を考える
 @Serializable
 data class MapUiState(
   val isMapLoading: Boolean,
+  val uiState: UiState,
+  val shouldRequestPermission: Boolean,
   val currentLocation: Location?,
   val smokingAreaList: List<SmokingArea>,
 ) {
+  @Serializable
+  sealed interface UiState {
+    val isMapShown: Boolean
+
+    @Serializable
+    data object PermissionRequested : UiState {
+      override val isMapShown: Boolean = false
+    }
+
+    @Serializable
+    data class PermissionGranted(
+      val isPrecise: Boolean,
+    ) : UiState {
+      override val isMapShown: Boolean = true
+    }
+
+    @Serializable
+    data object PermissionDenied : UiState {
+      override val isMapShown: Boolean = true
+    }
+  }
+
   companion object {
     fun createInitial(): MapUiState = MapViewModelState.createInitial().run {
       MapUiState(
         isMapLoading = isMapLoading,
+        uiState = uiState,
+        shouldRequestPermission = shouldRequestPermission,
         currentLocation = null,
         smokingAreaList = smokingAreaList,
       )

--- a/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModel.kt
+++ b/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModel.kt
@@ -2,6 +2,7 @@ package app.kaito_dogi.smopin.feature.map
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.kaito_dogi.smopin.shared.domain.smokingArea.location.LocationPreferencesDataSource
 import app.kaito_dogi.smopin.shared.domain.smokingArea.location.Location
 import app.kaito_dogi.smopin.shared.domain.smokingArea.location.LocationRepository
 import app.kaito_dogi.smopin.shared.domain.smokingArea.smokingArea.SmokingAreaRepository
@@ -14,6 +15,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -22,21 +25,30 @@ import kotlinx.coroutines.launch
 @ViewModelKey(value = MapViewModel::class)
 @ContributesIntoMap(scope = AppScope::class)
 class MapViewModel(
-  locationRepository: LocationRepository,
+  private val locationRepository: LocationRepository,
+  private val locationPreferencesDataSource: LocationPreferencesDataSource,
   private val smokingAreaRepository: SmokingAreaRepository,
 ) : ViewModel() {
   private val viewModelState: MutableStateFlow<MapViewModelState> = MutableStateFlow(value = MapViewModelState.createInitial())
 
-  // TODO: isPreciseEnabled を正確な位置情報のパーミッションが付与されているかどうかで切り替える
-  private val currentLocation: Flow<Location?> = locationRepository.getCurrentLocation(isPreciseEnabled = false)
+  private val currentLocation: Flow<Location?> = viewModelState.flatMapLatest { state ->
+    when (val uiState = state.uiState) {
+      is MapUiState.UiState.PermissionGranted -> locationRepository.getCurrentLocation(isPreciseEnabled = uiState.isPrecise)
+      MapUiState.UiState.PermissionDenied,
+      MapUiState.UiState.PermissionRequested,
+      -> emptyFlow()
+    }
+  }
 
   val uiState: StateFlow<MapUiState> = viewModelState.combine(
     flow = currentLocation,
-  ) { viewModelState, currentLocation ->
+  ) { state, currentLocation ->
     MapUiState(
-      isMapLoading = viewModelState.isMapLoading,
+      isMapLoading = state.isMapLoading,
+      uiState = state.uiState,
+      shouldRequestPermission = state.shouldRequestPermission,
       currentLocation = currentLocation,
-      smokingAreaList = viewModelState.smokingAreaList,
+      smokingAreaList = state.smokingAreaList,
     )
   }.stateIn(
     scope = viewModelScope,
@@ -57,6 +69,34 @@ class MapViewModel(
       }.onFailure {
         // TODO: エラーハンドリング
       }
+    }
+
+    viewModelScope.launch {
+      locationPreferencesDataSource.getShouldRequestPermission().collect { shouldRequestPermission ->
+        viewModelState.update {
+          it.copy(
+            shouldRequestPermission = shouldRequestPermission,
+          )
+        }
+      }
+    }
+  }
+
+  fun onPermissionRequested() {
+    viewModelScope.launch {
+      locationPreferencesDataSource.updateShouldRequestPermission(shouldRequestPermission = false)
+    }
+  }
+
+  fun onPermissionResult(isGranted: Boolean, isPrecise: Boolean) {
+    viewModelState.update {
+      it.copy(
+        uiState = if (isGranted) {
+          MapUiState.UiState.PermissionGranted(isPrecise = isPrecise)
+        } else {
+          MapUiState.UiState.PermissionDenied
+        },
+      )
     }
   }
 

--- a/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModelState.kt
+++ b/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModelState.kt
@@ -6,11 +6,15 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MapViewModelState(
   val isMapLoading: Boolean,
+  val uiState: MapUiState.UiState,
+  val shouldRequestPermission: Boolean,
   val smokingAreaList: List<SmokingArea>,
 ) {
   companion object {
     fun createInitial(): MapViewModelState = MapViewModelState(
       isMapLoading = true,
+      uiState = MapUiState.UiState.PermissionRequested,
+      shouldRequestPermission = true,
       smokingAreaList = emptyList(),
     )
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ android-targetSdk = "36"
 androidx-activity = "1.12.2"
 androidx-appcompat = "1.7.1"
 androidx-core = "1.17.0"
+androidxDataStore = "1.1.7"
 androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.6"
 androidx-testExt = "1.3.0"
@@ -34,6 +35,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit = { module = "junit:junit", version.ref = "junit" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidxDataStorePreferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidxDataStore" }
 androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }

--- a/shared/domain/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/domain/smokingArea/location/LocationPreferencesDataSource.kt
+++ b/shared/domain/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/domain/smokingArea/location/LocationPreferencesDataSource.kt
@@ -1,0 +1,9 @@
+package app.kaito_dogi.smopin.shared.domain.smokingArea.location
+
+import kotlinx.coroutines.flow.Flow
+
+interface LocationPreferencesDataSource {
+  fun getShouldRequestPermission(): Flow<Boolean>
+
+  suspend fun updateShouldRequestPermission(shouldRequestPermission: Boolean)
+}

--- a/shared/location/build.gradle.kts
+++ b/shared/location/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
     commonMain.dependencies {
       implementation(projects.shared.common)
       implementation(projects.shared.data)
+      implementation(projects.shared.domain)
 
       implementation(libs.kotlinxCoroutinesCore)
     }
@@ -36,6 +37,7 @@ kotlin {
     }
 
     androidMain.dependencies {
+      implementation(libs.androidxDataStorePreferences)
       implementation(libs.gmsPlayServicesLocation)
       implementation(libs.kotlinxCoroutinesPlayServices)
     }

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/DefaultLocationPreferencesDataSource.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/DefaultLocationPreferencesDataSource.android.kt
@@ -1,0 +1,35 @@
+package app.kaito_dogi.smopin.shared.location
+
+import android.app.Application
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import app.kaito_dogi.smopin.shared.domain.smokingArea.location.LocationPreferencesDataSource
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private const val LOCATION_PREFERENCES_DATA_STORE_NAME: String = "location_preferences"
+private const val SHOULD_REQUEST_PERMISSION_KEY: String = "should_request_permission"
+private val Application.locationPreferencesDataStore by preferencesDataStore(name = LOCATION_PREFERENCES_DATA_STORE_NAME)
+
+@Inject
+internal class DefaultLocationPreferencesDataSource(
+  private val application: Application,
+) : LocationPreferencesDataSource {
+  override fun getShouldRequestPermission(): Flow<Boolean> = application.locationPreferencesDataStore.data
+    .map { preferences ->
+      preferences[shouldRequestPermissionPreferencesKey] ?: true
+    }
+
+  override suspend fun updateShouldRequestPermission(shouldRequestPermission: Boolean) {
+    application.locationPreferencesDataStore.edit { preferences ->
+      preferences[shouldRequestPermissionPreferencesKey] = shouldRequestPermission
+    }
+  }
+
+  private companion object {
+    val shouldRequestPermissionPreferencesKey: Preferences.Key<Boolean> = booleanPreferencesKey(name = SHOULD_REQUEST_PERMISSION_KEY)
+  }
+}

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/LocationPreferencesBindingContainer.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/LocationPreferencesBindingContainer.kt
@@ -1,0 +1,12 @@
+package app.kaito_dogi.smopin.shared.location
+
+import app.kaito_dogi.smopin.shared.domain.smokingArea.location.LocationPreferencesDataSource
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.Binds
+
+@BindingContainer
+abstract class LocationPreferencesBindingContainer private constructor() {
+
+  @Binds
+  internal abstract val DefaultLocationPreferencesDataSource.bind: LocationPreferencesDataSource
+}


### PR DESCRIPTION
### Motivation
- Map画面で初回のみ位置情報許可ダイアログを表示し、許可状況に応じて地図表示と現在位置表示を制御する要件を満たすための実装を追加しました。  

### Description
- `MapUiState` を拡張して `UiState`（`PermissionRequested` / `PermissionGranted(isPrecise)` / `PermissionDenied`）を導入し、`UiState#isMapShown` で地図表示可否を判定するようにしました。  
- `MapViewModelState` の初期値を `PermissionRequested` + `shouldRequestPermission = true` に変更し、`MapViewModel` は `LocationPreferencesDataSource` を購読して `shouldRequestPermission` を反映し、`PermissionGranted` の場合のみ位置情報 Flow を購読するように変更しました。  
- `MapScreen` にランタイム権限の現在状態確認、`rememberLauncherForActivityResult` を使ったパーミッションダイアログ起動、および結果ハンドリング（`onPermissionRequested` / `onPermissionResult`）を実装し、`PermissionGranted` の場合のみ `isMyLocationEnabled` を有効化するようにしました。  
- 永続化用のフラグ用インターフェース `LocationPreferencesDataSource` を `shared:domain` に追加し、Android 実装として DataStore ベースの `DefaultLocationPreferencesDataSource` を `shared:location` に追加、Metro の `LocationPreferencesBindingContainer` を経由して DI 登録し、依存関係は `domain` インターフェース + `location` 実装の形にしました。  
- `datastore-preferences` 依存を `gradle/libs.versions.toml` と `shared/location/build.gradle.kts` に追加しました。  

### Testing
- 実行した自動ビルド: `./gradlew :android:feature:map:compileDebugKotlin :shared:location:compileDebugKotlinAndroid :android:app:compileDebugKotlin --stacktrace` は、実行環境側の Java バージョン判定（値 `25.0.1` のパース）により Gradle が失敗してビルドを完了できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84c6cc2ac83209ba7798b601e906a)