### PR TITLE
FusedClient から callbackFlow で位置情報をオブザーバブルに受け取る

### DIFF
--- a/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModel.kt
+++ b/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModel.kt
@@ -29,7 +29,7 @@ class MapViewModel(
   private val viewModelState: MutableStateFlow<MapViewModelState> = MutableStateFlow(value = MapViewModelState.createInitial())
 
   // TODO: isPreciseEnabled を正確な位置情報のパーミッションが付与されているかどうかで切り替える
-  private val currentLocation: Flow<Location?> = locationRepository.getCurrentLocation(
+  private val currentLocation: Flow<Location?> = locationRepository.getCurrentLocationStream(
     isPreciseEnabled = false,
     intervalDuration = 5.seconds,
   )

--- a/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModel.kt
+++ b/android/feature/map/src/main/kotlin/app/kaito_dogi/smopin/feature/map/MapViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 @Inject
 @ViewModelKey(value = MapViewModel::class)
@@ -28,7 +29,10 @@ class MapViewModel(
   private val viewModelState: MutableStateFlow<MapViewModelState> = MutableStateFlow(value = MapViewModelState.createInitial())
 
   // TODO: isPreciseEnabled を正確な位置情報のパーミッションが付与されているかどうかで切り替える
-  private val currentLocation: Flow<Location?> = locationRepository.getCurrentLocation(isPreciseEnabled = false)
+  private val currentLocation: Flow<Location?> = locationRepository.getCurrentLocation(
+    isPreciseEnabled = false,
+    intervalDuration = 5.seconds,
+  )
 
   val uiState: StateFlow<MapUiState> = viewModelState.combine(
     flow = currentLocation,

--- a/doc/architecture-layer-data.md
+++ b/doc/architecture-layer-data.md
@@ -65,7 +65,7 @@ data class UserDataModel(
 interface UserRepository {
   suspend fun getUserList(): List<User>
   suspend fun createUser(user: User)
-  fun getUser(userId: UserId): Flow<User>
+  fun getUserStream(userId: UserId): Flow<User>
   suspend fun updateUser(user: User)
   suspend fun deleteUser(userId: UserId)
 }
@@ -75,6 +75,7 @@ interface UserRepository {
 - ワンショットな読み取り処理は `suspend fun` で定義する
 - オブザーバルな読み取り処理は `suspend fun` を使用せず、返り値に `Flow` を使用する
 - 返り値が `List`, `Map`, `Set` の場合、メソッド名に接尾辞 `List`, `Map`, `Set` をつける
+- 返り値が `Flow` の場合、メソッド名に接尾辞 `Stream` をつける
 
 #### 実装例
 
@@ -82,12 +83,12 @@ interface UserRepository {
 @Inject
 internal class DefaultUserRepository(
   private val userNetworkDataSource: UserNetworkDataSource,
-  private val userDiskDataSource: UserDiskDataSource,
+  private val userPreferencesDataSource: UserPreferencesDataSource,
 ) : UserRepository {
   override suspend fun getUserList(): List<User> = userNetworkDataSource.getUserList()
     .map(transform = UserMapper::toDomainModel)
 
-  override fun getUser(userId: UserId): Flow<User> = userDiskDataSource.getUser(userId = userId)
+  override fun getUserStream(userId: UserId): Flow<User> = userPreferencesDataSource.getUserStream(userId = userId)
     .map(transform = UserMapper::toDomainModel)
 
   // override suspend fun createUser(user: User)
@@ -131,7 +132,8 @@ interface UserNetworkDataSource {
 - CRUD 処理は `create`, `get`, `update`, `delete` と命名する
 - ワンショットな読み取り処理は `suspend fun` で定義する
 - オブザーバルな読み取り処理は `suspend fun` を使用せず、返り値に `Flow` を使用する
-- 返り値が List の場合、メソッド名に接尾辞 `List` をつける
+- 返り値が `List`, `Map`, `Set` の場合、メソッド名に接尾辞 `List`, `Map`, `Set` をつける
+- 返り値が `Flow` の場合、メソッド名に接尾辞 `Stream` をつける
 
 #### 実装例
 

--- a/doc/convention-coding.md
+++ b/doc/convention-coding.md
@@ -9,9 +9,16 @@
 
 ### 返り値が `List`, `Map`, `Set` の場合、メソッド名に接尾辞 `List`, `Map`, `Set` をつける
 
-- 理由：命名で何の型か判断できるようにするため
+- 理由：命名で Collection の型を判断できるようにするため
 - OK：`getSmokingAreaList`
 - NG：`getSmokingAreas`
+
+### 返り値が `Flow` の場合、メソッド名に接尾辞 `Stream` をつける
+
+- 理由：命名でオブザーバルな値（ストリーム）を判断できるようにするため
+- OK：`getSmokingAreaListStream`
+- NG：`getSmokingAreaListFlow`
+- NG：`getSmokingAreaList`（接尾辞 `Stream` をつけない）
 
 ## 文法
 

--- a/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/DefaultLocationRepository.kt
+++ b/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/DefaultLocationRepository.kt
@@ -11,10 +11,10 @@ import kotlin.time.Duration
 internal class DefaultLocationRepository(
   private val locationDataSource: LocationDataSource,
 ) : LocationRepository {
-  override fun getCurrentLocation(
+  override fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
-  ): Flow<Location?> = locationDataSource.getCurrentLocation(
+  ): Flow<Location?> = locationDataSource.getCurrentLocationStream(
     isPreciseEnabled = isPreciseEnabled,
     intervalDuration = intervalDuration,
   )

--- a/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/DefaultLocationRepository.kt
+++ b/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/DefaultLocationRepository.kt
@@ -5,11 +5,18 @@ import app.kaito_dogi.smopin.shared.domain.smokingArea.location.LocationReposito
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlin.time.Duration
 
 @Inject
 internal class DefaultLocationRepository(
   private val locationDataSource: LocationDataSource,
 ) : LocationRepository {
-  override fun getCurrentLocation(isPreciseEnabled: Boolean): Flow<Location?> = locationDataSource.getCurrentLocation(isPreciseEnabled = isPreciseEnabled)
+  override fun getCurrentLocation(
+    isPreciseEnabled: Boolean,
+    intervalDuration: Duration,
+  ): Flow<Location?> = locationDataSource.getCurrentLocation(
+    isPreciseEnabled = isPreciseEnabled,
+    intervalDuration = intervalDuration,
+  )
     .map(transform = LocationMapper::toDomainModel)
 }

--- a/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationDataSource.kt
+++ b/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationDataSource.kt
@@ -5,7 +5,7 @@ import kotlin.time.Duration
 
 // TODO: interface にデフォルト引数を渡せるかどうか確認する
 interface LocationDataSource {
-  fun getCurrentLocation(
+  fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
   ): Flow<LocationDataModel?>

--- a/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationDataSource.kt
+++ b/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationDataSource.kt
@@ -3,7 +3,6 @@ package app.kaito_dogi.smopin.shared.data.location
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
-// TODO: interface にデフォルト引数を渡せるかどうか確認する
 interface LocationDataSource {
   fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,

--- a/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationDataSource.kt
+++ b/shared/data/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationDataSource.kt
@@ -2,12 +2,11 @@ package app.kaito_dogi.smopin.shared.data.location
 
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 // TODO: interface にデフォルト引数を渡せるかどうか確認する
 interface LocationDataSource {
   fun getCurrentLocation(
     isPreciseEnabled: Boolean,
-    intervalDuration: Duration = 5.seconds,
+    intervalDuration: Duration,
   ): Flow<LocationDataModel?>
 }

--- a/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationRepositoryTest.kt
+++ b/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationRepositoryTest.kt
@@ -1,0 +1,82 @@
+package app.kaito_dogi.smopin.shared.data.location
+
+import app.kaito_dogi.smopin.shared.domain.smokingArea.location.Latitude
+import app.kaito_dogi.smopin.shared.domain.smokingArea.location.Location
+import app.kaito_dogi.smopin.shared.domain.smokingArea.location.Longitude
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+internal class LocationRepositoryTest {
+  @Test
+  fun getSmokingAreaListSuccess() = runTest {
+    val locationRepository = DefaultLocationRepository(
+      locationDataSource = FakeLocationDataSource(),
+    )
+
+    val expectedLocation = fakeLocation.let {
+      Location(
+        latitude = Latitude(value = it.latitude),
+        longitude = Longitude(value = it.latitude),
+      )
+    }
+
+    val actualLocation = locationRepository.getCurrentLocationStream(
+      isPreciseEnabled = IS_PRECISE_ENABLED,
+      intervalDuration = INTERVAL_DURATION,
+    ).first()
+
+    assertEquals(expected = expectedLocation, actual = actualLocation)
+  }
+
+  @Test
+  fun getSmokingAreaListError() = runTest {
+    val locationRepository = DefaultLocationRepository(
+      locationDataSource = FakeLocationDataSource(
+        shouldFailGetCurrentLocationStream = true,
+      ),
+    )
+
+    // TODO: Exception をテストできるようにする
+    try {
+      locationRepository.getCurrentLocationStream(
+        isPreciseEnabled = IS_PRECISE_ENABLED,
+        intervalDuration = INTERVAL_DURATION,
+      ).first()
+    } catch (e: Exception) {
+      assertTrue { true }
+    }
+  }
+
+  companion object {
+    private const val IS_PRECISE_ENABLED = false
+    private val INTERVAL_DURATION = 5.seconds
+  }
+}
+
+private class FakeLocationDataSource(
+  private val location: LocationDataModel = fakeLocation,
+  private val shouldFailGetCurrentLocationStream: Boolean = false,
+) : LocationDataSource {
+  override fun getCurrentLocationStream(
+    isPreciseEnabled: Boolean,
+    intervalDuration: Duration
+  ): Flow<LocationDataModel?> = flow {
+    if (!shouldFailGetCurrentLocationStream) {
+      emit(value = location)
+    } else {
+      throw Exception()
+    }
+  }
+}
+
+private val fakeLocation: LocationDataModel = LocationDataModel(
+  latitude = 0.0,
+  longitude = 0.0,
+)

--- a/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationRepositoryTest.kt
+++ b/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationRepositoryTest.kt
@@ -9,13 +9,13 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertFails
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 internal class LocationRepositoryTest {
   @Test
-  fun getSmokingAreaListSuccess() = runTest {
+  fun getCurrentLocationStreamSuccess() = runTest {
     val locationRepository = DefaultLocationRepository(
       locationDataSource = FakeLocationDataSource(),
     )
@@ -23,7 +23,7 @@ internal class LocationRepositoryTest {
     val expectedLocation = fakeLocation.let {
       Location(
         latitude = Latitude(value = it.latitude),
-        longitude = Longitude(value = it.latitude),
+        longitude = Longitude(value = it.longitude),
       )
     }
 
@@ -36,21 +36,18 @@ internal class LocationRepositoryTest {
   }
 
   @Test
-  fun getSmokingAreaListError() = runTest {
+  fun getCurrentLocationStreamError() = runTest {
     val locationRepository = DefaultLocationRepository(
       locationDataSource = FakeLocationDataSource(
         shouldFailGetCurrentLocationStream = true,
       ),
     )
 
-    // TODO: Exception をテストできるようにする
-    try {
+    assertFails {
       locationRepository.getCurrentLocationStream(
         isPreciseEnabled = IS_PRECISE_ENABLED,
         intervalDuration = INTERVAL_DURATION,
       ).first()
-    } catch (e: Exception) {
-      assertTrue { true }
     }
   }
 

--- a/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationRepositoryTest.kt
+++ b/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/location/LocationRepositoryTest.kt
@@ -63,7 +63,7 @@ private class FakeLocationDataSource(
 ) : LocationDataSource {
   override fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,
-    intervalDuration: Duration
+    intervalDuration: Duration,
   ): Flow<LocationDataModel?> = flow {
     if (!shouldFailGetCurrentLocationStream) {
       emit(value = location)

--- a/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/smokingArea/SmokingAreaRepositoryTest.kt
+++ b/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/smokingArea/SmokingAreaRepositoryTest.kt
@@ -7,7 +7,7 @@ import app.kaito_dogi.smopin.shared.domain.smokingArea.smokingArea.SmokingArea
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertFails
 
 internal class SmokingAreaRepositoryTest {
   @Test
@@ -39,11 +39,8 @@ internal class SmokingAreaRepositoryTest {
       ),
     )
 
-    // TODO: Exception をテストできるようにする
-    try {
+    assertFails {
       smokingAreaRepository.getSmokingAreaList()
-    } catch (e: Exception) {
-      assertTrue { true }
     }
   }
 }

--- a/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/smokingArea/SmokingAreaRepositoryTest.kt
+++ b/shared/data/src/commonTest/kotlin/app/kaito_dogi/smopin/shared/data/smokingArea/SmokingAreaRepositoryTest.kt
@@ -11,12 +11,12 @@ import kotlin.test.assertTrue
 
 internal class SmokingAreaRepositoryTest {
   @Test
-  fun `getSmokingAreaList_Success`() = runTest {
+  fun getSmokingAreaListSuccess() = runTest {
     val smokingAreaRepository = DefaultSmokingAreaRepository(
       smokingAreaNetworkDataSource = FakeSmokingAreaNetworkDataSource(),
     )
 
-    val expect = fakeSmokingAreaDataModelList.map {
+    val expectedSmokingAreaList = fakeSmokingAreaDataModelList.map {
       SmokingArea(
         name = it.name,
         location = Location(
@@ -26,16 +26,16 @@ internal class SmokingAreaRepositoryTest {
       )
     }
 
-    val actual = smokingAreaRepository.getSmokingAreaList()
+    val actualSmokingAreaList = smokingAreaRepository.getSmokingAreaList()
 
-    assertEquals(expected = expect, actual = actual)
+    assertEquals(expected = expectedSmokingAreaList, actual = actualSmokingAreaList)
   }
 
   @Test
-  fun `getSmokingAreaList_Error`() = runTest {
+  fun getSmokingAreaListError() = runTest {
     val smokingAreaRepository = DefaultSmokingAreaRepository(
       smokingAreaNetworkDataSource = FakeSmokingAreaNetworkDataSource(
-        shouldThrow = true,
+        shouldFailGetSmokingAreaList = true,
       ),
     )
 
@@ -50,9 +50,9 @@ internal class SmokingAreaRepositoryTest {
 
 private class FakeSmokingAreaNetworkDataSource(
   private val smokingAreaList: List<SmokingAreaDataModel> = fakeSmokingAreaDataModelList,
-  private val shouldThrow: Boolean = false,
+  private val shouldFailGetSmokingAreaList: Boolean = false,
 ) : SmokingAreaNetworkDataSource {
-  override suspend fun getSmokingAreaList(): List<SmokingAreaDataModel> = if (!shouldThrow) {
+  override suspend fun getSmokingAreaList(): List<SmokingAreaDataModel> = if (!shouldFailGetSmokingAreaList) {
     smokingAreaList
   } else {
     throw Exception()

--- a/shared/domain/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/domain/smokingArea/location/LocationRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/domain/smokingArea/location/LocationRepository.kt
@@ -1,7 +1,11 @@
 package app.kaito_dogi.smopin.shared.domain.smokingArea.location
 
 import kotlinx.coroutines.flow.Flow
+import kotlin.time.Duration
 
 interface LocationRepository {
-  fun getCurrentLocation(isPreciseEnabled: Boolean): Flow<Location?>
+  fun getCurrentLocation(
+    isPreciseEnabled: Boolean,
+    intervalDuration: Duration,
+  ): Flow<Location?>
 }

--- a/shared/domain/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/domain/smokingArea/location/LocationRepository.kt
+++ b/shared/domain/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/domain/smokingArea/location/LocationRepository.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
 interface LocationRepository {
-  fun getCurrentLocation(
+  fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
   ): Flow<Location?>

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -20,7 +20,7 @@ internal actual class PlatformLocationClient(
   private val fusedLocationClient: FusedLocationProviderClient,
 ) {
   @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
-  actual fun getLocation(
+  actual fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
   ): Flow<LocationDataModel?> = callbackFlow {

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -24,6 +24,16 @@ internal actual class PlatformLocationClient(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
   ): Flow<LocationDataModel?> = callbackFlow {
+    require(value = intervalDuration.isFinite() && intervalDuration > Duration.ZERO) {
+      "intervalDuration must be finite and greater than zero: $intervalDuration"
+    }
+
+    val intervalMillis = intervalDuration.toLong(unit = DurationUnit.MILLISECONDS).apply {
+      require(value = this >= 1.0) {
+        "intervalDuration must be at least 1 millisecond when converted to milliseconds: $intervalDuration"
+      }
+    }
+
     val locationCallback = object : LocationCallback() {
       override fun onLocationResult(locationResult: LocationResult) {
         for (currentLocation in locationResult.locations) {
@@ -32,7 +42,7 @@ internal actual class PlatformLocationClient(
       }
     }
 
-    val locationRequest = LocationRequest.Builder(intervalDuration.toLong(unit = DurationUnit.MILLISECONDS))
+    val locationRequest = LocationRequest.Builder(intervalMillis)
       .setPriority(if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY)
       .build()
 

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -32,7 +32,6 @@ internal actual class PlatformLocationClient(
       }
     }
 
-    val looper = Looper.getMainLooper()
     val locationRequest = LocationRequest.Builder(intervalDuration.toLong(unit = DurationUnit.MILLISECONDS))
       .setPriority(if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY)
       .build()
@@ -40,14 +39,11 @@ internal actual class PlatformLocationClient(
     fusedLocationClient.requestLocationUpdates(
       locationRequest,
       locationCallback,
-      looper,
+      Looper.getMainLooper(),
     )
 
     awaitClose {
       fusedLocationClient.removeLocationUpdates(locationCallback)
-
-      // TODO: Looper の扱いを調べる
-      looper.quitSafely()
     }
   }
 }

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -1,7 +1,6 @@
 package app.kaito_dogi.smopin.shared.location
 
 import android.Manifest
-import android.app.Application
 import android.os.Looper
 import androidx.annotation.RequiresPermission
 import app.kaito_dogi.smopin.shared.data.location.LocationDataModel
@@ -19,14 +18,8 @@ import kotlin.time.DurationUnit
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 internal actual class PlatformLocationClient(
   private val fusedLocationClient: FusedLocationProviderClient,
-  private val application: Application,
 ) {
-  @RequiresPermission(
-    anyOf = [
-      Manifest.permission.ACCESS_FINE_LOCATION,
-      Manifest.permission.ACCESS_COARSE_LOCATION,
-    ],
-  )
+  @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
   actual fun getLocation(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
@@ -39,9 +32,10 @@ internal actual class PlatformLocationClient(
       }
     }
 
-    val locationRequest = LocationRequest.Builder(intervalDuration.toLong(unit = DurationUnit.MILLISECONDS)).setPriority(if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY).build()
-
     val looper = Looper.getMainLooper()
+    val locationRequest = LocationRequest.Builder(intervalDuration.toLong(unit = DurationUnit.MILLISECONDS))
+      .setPriority(if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY)
+      .build()
 
     fusedLocationClient.requestLocationUpdates(
       locationRequest,

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -44,6 +44,7 @@ internal actual class PlatformLocationClient(
 
     val locationRequest = LocationRequest.Builder(intervalMillis)
       .setPriority(if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY)
+      .setMinUpdateIntervalMillis(intervalMillis)
       .build()
 
     fusedLocationClient.requestLocationUpdates(

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -12,6 +12,7 @@ import com.google.android.gms.location.Priority
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 
@@ -51,10 +52,13 @@ internal actual class PlatformLocationClient(
       locationRequest,
       locationCallback,
       Looper.getMainLooper(),
-    )
+    ).addOnFailureListener { e: Exception ->
+      // TODO: エラーハンドリング
+      throw e
+    }
 
     awaitClose {
       fusedLocationClient.removeLocationUpdates(locationCallback)
     }
-  }
+  }.conflate()
 }

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -38,7 +38,11 @@ internal actual class PlatformLocationClient(
     val locationCallback = object : LocationCallback() {
       override fun onLocationResult(locationResult: LocationResult) {
         for (currentLocation in locationResult.locations) {
-          trySend(element = currentLocation.let(block = LocationMapper::toDataModel))
+          val channelResult = trySend(element = currentLocation.let(block = LocationMapper::toDataModel))
+          if (channelResult.isFailure) {
+            close(cause = channelResult.exceptionOrNull())
+            return
+          }
         }
       }
     }
@@ -52,9 +56,9 @@ internal actual class PlatformLocationClient(
       locationRequest,
       locationCallback,
       Looper.getMainLooper(),
-    ).addOnFailureListener { e: Exception ->
+    ).addOnFailureListener { cause: Exception ->
       // TODO: エラーハンドリング
-      throw e
+      close(cause = cause)
     }
 
     awaitClose {

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -30,7 +30,7 @@ internal actual class PlatformLocationClient(
     }
 
     val intervalMillis = intervalDuration.toLong(unit = DurationUnit.MILLISECONDS).apply {
-      require(value = this >= 1.0) {
+      require(value = this >= 1L) {
         "intervalDuration must be at least 1 millisecond when converted to milliseconds: $intervalDuration"
       }
     }

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -21,7 +21,12 @@ internal actual class PlatformLocationClient(
   private val fusedLocationClient: FusedLocationProviderClient,
   private val application: Application,
 ) {
-  @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+  @RequiresPermission(
+    anyOf = [
+      Manifest.permission.ACCESS_FINE_LOCATION,
+      Manifest.permission.ACCESS_COARSE_LOCATION,
+    ],
+  )
   actual fun getLocation(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
@@ -34,9 +39,7 @@ internal actual class PlatformLocationClient(
       }
     }
 
-    val locationRequest = LocationRequest.Builder(intervalDuration.toLong(unit = DurationUnit.MILLISECONDS))
-      .setPriority(if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY)
-      .build()
+    val locationRequest = LocationRequest.Builder(intervalDuration.toLong(unit = DurationUnit.MILLISECONDS)).setPriority(if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY).build()
 
     val looper = Looper.getMainLooper()
 

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.android.kt
@@ -1,17 +1,56 @@
 package app.kaito_dogi.smopin.shared.location
 
+import android.Manifest
+import android.app.Application
+import android.os.Looper
+import androidx.annotation.RequiresPermission
 import app.kaito_dogi.smopin.shared.data.location.LocationDataModel
 import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.Priority
-import com.google.android.gms.tasks.CancellationTokenSource
-import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 internal actual class PlatformLocationClient(
   private val fusedLocationClient: FusedLocationProviderClient,
+  private val application: Application,
 ) {
-  actual suspend fun getLocation(isPreciseEnabled: Boolean): LocationDataModel? = fusedLocationClient.getCurrentLocation(
-    if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY,
-    CancellationTokenSource().token,
-  ).await().let(block = LocationMapper::toDataModel)
+  @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
+  actual fun getLocation(
+    isPreciseEnabled: Boolean,
+    intervalDuration: Duration,
+  ): Flow<LocationDataModel?> = callbackFlow {
+    val locationCallback = object : LocationCallback() {
+      override fun onLocationResult(locationResult: LocationResult) {
+        for (currentLocation in locationResult.locations) {
+          trySend(element = currentLocation.let(block = LocationMapper::toDataModel))
+        }
+      }
+    }
+
+    val locationRequest = LocationRequest.Builder(intervalDuration.toLong(unit = DurationUnit.MILLISECONDS))
+      .setPriority(if (isPreciseEnabled) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY)
+      .build()
+
+    val looper = Looper.getMainLooper()
+
+    fusedLocationClient.requestLocationUpdates(
+      locationRequest,
+      locationCallback,
+      looper,
+    )
+
+    awaitClose {
+      fusedLocationClient.removeLocationUpdates(locationCallback)
+
+      // TODO: Looper の扱いを調べる
+      looper.quitSafely()
+    }
+  }
 }

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClientBindingContainer.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClientBindingContainer.kt
@@ -13,5 +13,6 @@ object PlatformLocationClientBindingContainer {
     application: Application,
   ): PlatformLocationClient = PlatformLocationClient(
     fusedLocationClient = LocationServices.getFusedLocationProviderClient(application),
+    application = application,
   )
 }

--- a/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClientBindingContainer.kt
+++ b/shared/location/src/androidMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClientBindingContainer.kt
@@ -13,6 +13,5 @@ object PlatformLocationClientBindingContainer {
     application: Application,
   ): PlatformLocationClient = PlatformLocationClient(
     fusedLocationClient = LocationServices.getFusedLocationProviderClient(application),
-    application = application,
   )
 }

--- a/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/DefaultLocationDataSource.kt
+++ b/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/DefaultLocationDataSource.kt
@@ -15,10 +15,10 @@ internal class DefaultLocationDataSource(
   private val platformLocationClient: PlatformLocationClient,
   @param:AppDispatcher(dispatcher = AppDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : LocationDataSource {
-  override fun getCurrentLocation(
+  override fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
-  ): Flow<LocationDataModel?> = platformLocationClient.getLocation(
+  ): Flow<LocationDataModel?> = platformLocationClient.getCurrentLocationStream(
     isPreciseEnabled = isPreciseEnabled,
     intervalDuration = intervalDuration,
   ).flowOn(

--- a/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/DefaultLocationDataSource.kt
+++ b/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/DefaultLocationDataSource.kt
@@ -6,12 +6,8 @@ import app.kaito_dogi.smopin.shared.data.location.LocationDataModel
 import app.kaito_dogi.smopin.shared.data.location.LocationDataSource
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.isActive
 import kotlin.time.Duration
 
 @Inject
@@ -22,14 +18,10 @@ internal class DefaultLocationDataSource(
   override fun getCurrentLocation(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
-  ): Flow<LocationDataModel?> = flow {
-    while (currentCoroutineContext().isActive) {
-      platformLocationClient.getLocation(isPreciseEnabled = isPreciseEnabled)?.let {
-        emit(value = it)
-      }
-      delay(duration = intervalDuration)
-    }
-  }.flowOn(
+  ): Flow<LocationDataModel?> = platformLocationClient.getLocation(
+    isPreciseEnabled = isPreciseEnabled,
+    intervalDuration = intervalDuration,
+  ).flowOn(
     context = ioDispatcher,
   )
 }

--- a/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.kt
+++ b/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.kt
@@ -1,7 +1,12 @@
 package app.kaito_dogi.smopin.shared.location
 
 import app.kaito_dogi.smopin.shared.data.location.LocationDataModel
+import kotlinx.coroutines.flow.Flow
+import kotlin.time.Duration
 
 internal expect class PlatformLocationClient {
-  suspend fun getLocation(isPreciseEnabled: Boolean): LocationDataModel?
+  fun getLocation(
+    isPreciseEnabled: Boolean,
+    intervalDuration: Duration,
+  ): Flow<LocationDataModel?>
 }

--- a/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.kt
+++ b/shared/location/src/commonMain/kotlin/app/kaito_dogi/smopin/shared/location/PlatformLocationClient.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
 internal expect class PlatformLocationClient {
-  fun getLocation(
+  fun getCurrentLocationStream(
     isPreciseEnabled: Boolean,
     intervalDuration: Duration,
   ): Flow<LocationDataModel?>


### PR DESCRIPTION
## 関連チケット

- close: #67 

## 背景

## 対応したこと

- [x] FusedClient から callbackFlow で位置情報をオブザーバブルに受け取る
- [x] Flow を返すメソッド名に接尾辞 `Stream` をつける
- [x] Flow を返すメソッド名に接尾辞 `Stream` をつけるをドキュメントに明記

## 対応していないこと

## UI 差分

|            Before            |            After             |
|:----------------------------:|:----------------------------:|
| <img src="" width="300px" /> | <img src="" width="300px" /> |

## 動作確認手順

- [ ] TBD

## 参照資料

- TBD
