### PR TITLE
docs: Codex向けGitHub connector運用を明文化

### DIFF
--- a/.agents/skills/address-review-comment-cycle/SKILL.md
+++ b/.agents/skills/address-review-comment-cycle/SKILL.md
@@ -20,10 +20,10 @@ description: プルリクエストのレビューコメント対応サイクル�
 ## リソース
 
 - `scripts/fetch-review-state.sh`：プルリクエストのメタデータ、レビュー会話、プルリクエストコメント、レビュー要約を JSON で取得する
-- `references/github-cli.md`：スクリプトだけでは足りない場合の `gh` コマンド例を確認する
-- `references/github-connector.md`：`gh` の権限で解決できない場合の代替手順を確認する
+- `references/github-connector.md`：Codex アプリで GitHub connector を使う手順と対応する操作を確認する
+- `references/github-cli.md`：`gh` を使う手順と対応する操作を確認する
 
-まずはスクリプトを使い、失敗した場合やレビュー会話への返信・解決などの個別操作が必要な場合だけリファレンスを読む。
+まずはスクリプトを使い、個別操作が必要になったら GitHub connector と `gh` のどちらで実行するかを選ぶ。Codex アプリでは GitHub connector を最初から候補に含め、`gh` の代替ではなく同格の選択肢として扱う。
 
 ## ワークフロー
 
@@ -107,7 +107,7 @@ git push origin HEAD
 - 説明する場合：なぜ変更しないかを書く
 - 延期する場合：作成した Issue URL と、なぜ今回扱わないかを書く
 
-返信後、解決できるレビュー会話を解決済みにする。詳細な `gh` 操作が必要な場合は `references/github-cli.md` を読む。
+返信後、解決できるレビュー会話を解決済みにする。GitHub connector または `gh` の詳細な操作が必要な場合は、対応するリファレンスを読む。
 
 解決操作後は、GitHub 上で解決済みになっていないレビュー会話が残っていないことを確認する。
 
@@ -137,7 +137,17 @@ git push origin HEAD
 - <レビューコメント URL またはプルリクエスト URL>
 ```
 
-Issue 作成例：
+GitHub connector の Issue 作成例：
+
+```text
+mcp__codex_apps__github._create_issue
+```
+
+- `repository_full_name`：`owner/name`
+- `title`：Issue タイトル
+- `body`：Issue 本文
+
+`gh` の Issue 作成例：
 
 ```bash
 gh issue create \
@@ -149,11 +159,13 @@ gh issue create \
 
 ### 8. 再レビューを依頼する
 
-push 後に Gemini Code Assist などの AI エージェントへレビューを依頼または再依頼する。
+push 後に Gemini Code Assist などの AI エージェントへレビューを依頼または再依頼する。GitHub connector と `gh` のどちらを使ってもよい。
 
 ```bash
 gh pr comment <pull-request-number-or-url> --body "/gemini review"
 ```
+
+GitHub connector を使う場合は、プルリクエスト会話へのトップレベルコメントとして `/gemini review` を投稿する。
 
 ### 9. 追加コメントを確認する
 

--- a/.agents/skills/address-review-comment-cycle/SKILL.md
+++ b/.agents/skills/address-review-comment-cycle/SKILL.md
@@ -161,11 +161,21 @@ gh issue create \
 
 push 後に Gemini Code Assist などの AI エージェントへレビューを依頼または再依頼する。GitHub connector と `gh` のどちらを使ってもよい。
 
+GitHub connector のコメント投稿例：
+
+```text
+mcp__codex_apps__github._add_comment_to_issue
+```
+
+- `repo_full_name`：`owner/name`
+- `pr_number`：プルリクエスト番号
+- `comment`：`/gemini review`
+
+`gh` のコメント投稿例：
+
 ```bash
 gh pr comment <pull-request-number-or-url> --body "/gemini review"
 ```
-
-GitHub connector を使う場合は、プルリクエスト会話へのトップレベルコメントとして `/gemini review` を投稿する。
 
 ### 9. 追加コメントを確認する
 

--- a/.agents/skills/address-review-comment-cycle/references/github-cli.md
+++ b/.agents/skills/address-review-comment-cycle/references/github-cli.md
@@ -104,7 +104,7 @@ gh api graphql \
 gh pr comment <pull-request-number-or-url> --body "/gemini review"
 ```
 
-GitHub connector を使う場合は、`_add_comment_to_issue` で同じ本文を投稿する。
+GitHub connector を使う場合は、`mcp__codex_apps__github._add_comment_to_issue` で同じ本文を投稿する。
 
 ## ポーリング方針
 

--- a/.agents/skills/address-review-comment-cycle/references/github-cli.md
+++ b/.agents/skills/address-review-comment-cycle/references/github-cli.md
@@ -1,6 +1,6 @@
 # レビューコメント対応のための GitHub CLI リファレンス
 
-補助スクリプトだけでは足りない場合、またはより細かく GitHub API を操作したい場合に参照する。
+補助スクリプトだけでは足りない場合、またはより細かく GitHub API を操作したい場合に参照する。Codex アプリでは GitHub connector も同格のデフォルト選択肢なので、このファイルは `gh` を選ぶときの具体例として扱う。
 
 ## プルリクエスト番号または URL を解決する
 
@@ -96,13 +96,15 @@ gh api graphql \
   -f query='mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) { thread { id isResolved } } }'
 ```
 
-`gh api graphql` が認証や権限で失敗する場合は、`references/github-connector.md` を確認する。
+`gh api graphql` が認証や権限で失敗する場合や、Codex アプリから安定して操作したい場合は、`references/github-connector.md` を確認する。
 
 ## Gemini Code Assist に再レビューを依頼する
 
 ```bash
 gh pr comment <pull-request-number-or-url> --body "/gemini review"
 ```
+
+GitHub connector を使う場合は、`_add_comment_to_issue` で同じ本文を投稿する。
 
 ## ポーリング方針
 

--- a/.agents/skills/address-review-comment-cycle/references/github-connector.md
+++ b/.agents/skills/address-review-comment-cycle/references/github-connector.md
@@ -65,5 +65,9 @@ mcp__codex_apps__github._resolve_review_thread
 ## 注意
 
 - 返信を先に投稿してから解決する
+- パラメータ名は実際の connector schema に合わせる
+- `mcp__codex_apps__github._create_pull_request` と `mcp__codex_apps__github._create_issue` では `repository_full_name` を使う
+- `mcp__codex_apps__github._reply_to_review_comment` と `mcp__codex_apps__github._add_comment_to_issue` では `repo_full_name` を使う
+- `mcp__codex_apps__github._add_comment_to_issue` はプルリクエスト会話への投稿でも schema 上の `pr_number` を使う
 - GitHub connector に存在しない操作や、現在のセッションで tool が公開されていない操作だけ `gh` を使う
 - GitHub connector が使えない場合は、GitHub 上で手動対応するか、`gh` の認証スコープを見直す

--- a/.agents/skills/address-review-comment-cycle/references/github-connector.md
+++ b/.agents/skills/address-review-comment-cycle/references/github-connector.md
@@ -1,26 +1,69 @@
 # GitHub Connector リファレンス
 
-`gh api graphql` でレビュー会話の解決が `Resource not accessible by personal access token` などの権限エラーになる場合に参照する。
+Codex アプリで GitHub へ操作するときの基本リファレンスとして参照する。`gh` が不安定な場合の代替手段に限定せず、GitHub connector を `gh` と同格のデフォルト選択肢として扱う。
 
 ## 使いどころ
 
-- `gh api graphql` で `resolveReviewThread` が失敗する
-- PAT の権限や SAML 制約で `gh` からは操作できない
+- Codex アプリから GitHub へ直接操作したい
+- `gh` が不安定、または認証や権限で失敗する
+- プルリクエスト作成、Issue 作成、コメント返信、レビュー会話の解決をツール経由で行いたい
 - Codex 環境で GitHub connector が利用できる
 
-## 代替手順
+## 主な操作
 
-GitHub connector の `_resolve_review_thread` を使って、GraphQL の review thread node ID を直接解決する。
+### プルリクエストを作成する
+
+```text
+mcp__codex_apps__github._create_pull_request
+```
+
+- `repository_full_name`：`owner/name`
+- `base`：ベースブランチ
+- `head`：プルリクエストブランチ
+- `title`：プルリクエストタイトル
+- `body`：プルリクエスト本文
+
+### Issue を作成する
+
+```text
+mcp__codex_apps__github._create_issue
+```
+
+- `repository_full_name`：`owner/name`
+- `title`：Issue タイトル
+- `body`：Issue 本文
+
+### インラインレビューコメントに返信する
+
+```text
+mcp__codex_apps__github._reply_to_review_comment
+```
+
+- `repo_full_name`：`owner/name`
+- `pr_number`：プルリクエスト番号
+- `comment_id`：スレッド先頭のレビューコメント ID
+- `comment`：返信本文
+
+### プルリクエスト会話へコメントする
+
+```text
+mcp__codex_apps__github._add_comment_to_issue
+```
+
+- `repo_full_name`：`owner/name`
+- `pr_number`：プルリクエスト番号
+- `comment`：コメント本文
+
+### レビュー会話を解決済みにする
 
 ```text
 mcp__codex_apps__github._resolve_review_thread
 ```
-
-必要なものは次のとおり。
 
 - `thread_id`：`PRRT_...` 形式の review thread node ID
 
 ## 注意
 
 - 返信を先に投稿してから解決する
-- GitHub connector が使えない場合は、GitHub 上で手動解決するか、`gh` の認証スコープを見直す
+- GitHub connector に存在しない操作や、現在のセッションで tool が公開されていない操作だけ `gh` を使う
+- GitHub connector が使えない場合は、GitHub 上で手動対応するか、`gh` の認証スコープを見直す

--- a/.agents/skills/create-pull-request/SKILL.md
+++ b/.agents/skills/create-pull-request/SKILL.md
@@ -3,7 +3,7 @@ name: create-pull-request
 description: このリポジトリの Git 運用に沿って GitHub プルリクエストを作成する。ユーザーが PR 作成、プルリクエスト作成、作業完了後の PR 化、またはブランチ作成・コミット・push・PR 作成の一連の作業を依頼したときに使用する。
 ---
 
-# Create Pull Request
+# プルリクエスト作成
 
 このスキルは、リポジトリ上の作業をレビュー可能な GitHub プルリクエストとして完了するために使用する。
 
@@ -28,15 +28,17 @@ description: このリポジトリの Git 運用に沿って GitHub プルリク
 6. 最小限で有効な検証を先に実行し、変更範囲に応じてより広い検証を実行する
 7. `docs/convention-commit.md` に従って Conventional Commits 形式でコミットする
 8. ブランチを push する
-9. `mkdir -p /tmp/pr-body` を実行する
-10. プルリクエスト本文を作成し、`/tmp/pr-body/ISSUE-{issue-number}.md` に保存する
+9. `gh` を使う可能性がある場合は `mkdir -p /tmp/pr-body` を実行する
+10. プルリクエスト本文を作成する。`gh` を使う場合は、`/tmp/pr-body/ISSUE-{issue-number}.md` に保存する
 11. ユーザーが明示的に止めていない限り、追加の指示を待たずにプルリクエストを作成する
 
 ## プルリクエスト作成
 
-プルリクエストは `gh pr create` で作成する。
+プルリクエスト作成には GitHub connector の `_create_pull_request` または `gh pr create` を使用する。
 
-このリポジトリでは、開発者が Fine-grained personal access tokens で `gh` 認証済みであることを前提とする。GitHub connector や MCP tool でプルリクエストを作成しない。
+Codex アプリでは `gh` が不安定なことがあるため、GitHub connector を `gh` と同格のデフォルト選択肢として扱う。特に、Codex アプリからそのまま GitHub へ操作を送る場合は、GitHub connector を優先してよい。
+
+`gh` を使う場合は、開発者が Fine-grained personal access tokens で `gh` 認証済みであることを前提とする。
 
 ### ベースブランチ
 
@@ -85,7 +87,20 @@ description: このリポジトリの Git 運用に沿って GitHub プルリク
 - TBD
 ```
 
-作成例：
+GitHub connector の作成例：
+
+```text
+mcp__codex_apps__github._create_pull_request
+```
+
+- `repository_full_name`：`owner/name`
+- `base`：ベースブランチ
+- `head`：プルリクエストブランチ
+- `title`：Conventional Commits 形式のタイトル
+- `body`：プルリクエスト本文
+- `draft`：必要に応じて指定する
+
+`gh` の作成例：
 
 ```bash
 gh pr create --base main --head feature/ISSUE-89_create-pull-request-skill --title "docs: add git workflow documents" --body-file /tmp/pr-body/ISSUE-89.md

--- a/.agents/skills/create-pull-request/SKILL.md
+++ b/.agents/skills/create-pull-request/SKILL.md
@@ -28,13 +28,13 @@ description: このリポジトリの Git 運用に沿って GitHub プルリク
 6. 最小限で有効な検証を先に実行し、変更範囲に応じてより広い検証を実行する
 7. `docs/convention-commit.md` に従って Conventional Commits 形式でコミットする
 8. ブランチを push する
-9. `gh` を使う可能性がある場合は `mkdir -p /tmp/pr-body` を実行する
-10. プルリクエスト本文を作成する。`gh` を使う場合は、`/tmp/pr-body/ISSUE-{issue-number}.md` に保存する
+9. `mkdir -p /tmp/pr-body` を実行する
+10. プルリクエスト本文を作成し、`/tmp/pr-body/ISSUE-{issue-number}.md` に保存する
 11. ユーザーが明示的に止めていない限り、追加の指示を待たずにプルリクエストを作成する
 
 ## プルリクエスト作成
 
-プルリクエスト作成には GitHub connector の `_create_pull_request` または `gh pr create` を使用する。
+プルリクエスト作成には GitHub connector の `mcp__codex_apps__github._create_pull_request` または `gh pr create` を使用する。
 
 Codex アプリでは `gh` が不安定なことがあるため、GitHub connector を `gh` と同格のデフォルト選択肢として扱う。特に、Codex アプリからそのまま GitHub へ操作を送る場合は、GitHub connector を優先してよい。
 


### PR DESCRIPTION
## 関連チケット

- close: #96

## 背景

Codex アプリ環境では `gh` コマンドが安定しない場面があり、GitHub 操作を `gh` 前提で書いた Skill やリファレンスが実運用とずれていました。
また、`create-pull-request` Skill の表示名が本文見出し由来で英語表示になっており、他の日本語ドキュメントと不整合でした。

## 対応したこと

- `create-pull-request` Skill を更新し、GitHub connector を `gh` と同格のデフォルト選択肢として扱う方針を明記した
- レビュー対応サイクル Skill と GitHub CLI / GitHub connector リファレンスを更新し、Codex アプリでは GitHub connector を最初から候補に含める運用に揃えた
- `create-pull-request` Skill の先頭見出しを日本語化し、Skill 表示名が運用文書の言語方針と揃うようにした

## 対応していないこと

- GitHub connector を前提にした運用変更は `.agents/skills` 配下に限定しており、他の Skill 全体の表示名監査や文言統一は行っていない

## UI 差分

- なし

## 動作確認手順

- [x] `git diff --check`

## 参照資料

- `docs/convention-docs.md`
- `docs/convention-commit.md`
- `docs/strategy-branch.md`
- https://github.com/Kaito-Dogi/smopin/issues/96